### PR TITLE
Aggregrate queries in ruler alert format

### DIFF
--- a/sigma/backends/loki/loki.py
+++ b/sigma/backends/loki/loki.py
@@ -992,8 +992,8 @@ class LogQLBackend(TextQueryBackend):
         alert = self.field_replace_pattern.sub("_", rule.title).strip("_")
         ruler = {
             "alert": alert,
-            "annotations": {"message": rule.title, "summary": rule.description},
-            "expr": query,
+            "annotations": {"description": rule.title, "summary": rule.description},
+            "expr": f"sum(count_over_time({query} [1m])) or vector(0) > 0",
             "labels": {},
         }
         if rule.level:

--- a/tests/test_backend_loki.py
+++ b/tests/test_backend_loki.py
@@ -1092,9 +1092,9 @@ def test_loki_ruler_output(loki_backend: LogQLBackend):
   rules:
   - alert: test_signature
     annotations:
-      message: test signature
+      description: test signature
       summary: testing
-    expr: '{job=~".+"} |= `anything`'
+    expr: sum(count_over_time({job=~".+"} |= `anything` [1m])) or vector(0) > 0
     labels:
       severity: low
 """


### PR DESCRIPTION
When producing alerts in Loki, log queries need to produce a vector/scalar result from an aggregation, rather than the raw log entries.

To achieve this, wrap each query with:
```
sum(count_over_time(... [1m])) or vector(0) > 0
```
The choice of a 1 minute window was somewhat arbitrary - it is inline with the default alert query window used in Loki.

Also change the name of the longer alert information from message (which was used in the Loki documentation) to the more standard description (used in the Prometheus documentation and expected by Grafana).