### PR TITLE
Swap description and summary in alert format

### DIFF
--- a/sigma/backends/loki/loki.py
+++ b/sigma/backends/loki/loki.py
@@ -992,7 +992,7 @@ class LogQLBackend(TextQueryBackend):
         alert = self.field_replace_pattern.sub("_", rule.title).strip("_")
         ruler = {
             "alert": alert,
-            "annotations": {"description": rule.title, "summary": rule.description},
+            "annotations": {"description": rule.description, "summary": rule.title},
             "expr": f"sum(count_over_time({query} [1m])) or vector(0) > 0",
             "labels": {},
         }

--- a/tests/test_backend_loki.py
+++ b/tests/test_backend_loki.py
@@ -1092,8 +1092,8 @@ def test_loki_ruler_output(loki_backend: LogQLBackend):
   rules:
   - alert: test_signature
     annotations:
-      description: test signature
-      summary: testing
+      description: testing
+      summary: test signature
     expr: sum(count_over_time({job=~".+"} |= `anything` [1m])) or vector(0) > 0
     labels:
       severity: low


### PR DESCRIPTION
The longer value in most signatures is in the description, so it makes more sense to use that as the alert description, and the title as a summary.