### PR TITLE
Fix wildcarded unbound OR line filters

### DIFF
--- a/tests/test_backend_loki.py
+++ b/tests/test_backend_loki.py
@@ -750,6 +750,28 @@ def test_loki_or_unbound(loki_backend: LogQLBackend):
     )
 
 
+def test_loki_or_unbound_wildcard(loki_backend: LogQLBackend):
+    assert (
+        loki_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                keywords:
+                    - '*valueA'
+                    - 'valueB*'
+                condition: keywords
+        """
+            )
+        )
+        == ['{job=~".+"} |~ `(?i).*valueA|valueB.*`']
+    )
+
+
 def test_loki_or_unbound_tilde_double_quote(loki_backend: LogQLBackend):
     assert (
         loki_backend.convert(


### PR DESCRIPTION
The code to convert unbound OR string expressions did not take into account the possibility that those strings might contain wildcards, and hence the wildcards were being passed through to the query without modification (beyond being escaped as RE metacharacters).

This code fixes that by testing for whether there are any wildcards and ensuring they are converted appropriately. In the future, this could also allow full regular expressions from the query to be included; however, given the wide range of possible inputs and the limited use of such a feature in Sigma rules, this is still not permitted by this code and will still lead to an error.