### PR TITLE
Strip leading and trailing wildcards from unbound line filters

### DIFF
--- a/tests/test_backend_negation_loki.py
+++ b/tests/test_backend_negation_loki.py
@@ -382,7 +382,7 @@ def test_loki_not_wildcard_unbound(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} !~ `(?i)va.ue.*`']
+        == ['{job=~".+"} !~ `(?i)va.ue`']
     )
 
 
@@ -483,12 +483,12 @@ def test_loki_not_unbound_re_wildcard(loki_backend: LogQLBackend):
                 product: test_product
             detection:
                 keywords:
-                    value*
+                    '|re': 'value.*'
                 condition: not keywords
         """
             )
         )
-        == ['{job=~".+"} !~ `(?i)value.*`']
+        == ['{job=~".+"} !~ `value`']
     )
 
 
@@ -621,7 +621,7 @@ def test_loki_not_unbound_wildcard(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} !~ `(?i)value.*`']
+        == ['{job=~".+"} !~ `(?i)value`']
     )
 
 


### PR DESCRIPTION
Regular expression line filters that include any length wildcards (i.e., .*) at the beginning or end of the regex do not require those wildcards, since they are implicit in the definition of a [line filter](https://grafana.com/docs/loki/latest/logql/log_queries/#line-filter-expression). Using them could lead to reduced performance of queries, as well as triggering unusual edge cases in Loki behaviour (e.g., grafana/loki#7837) - so this code automatically removes them (and only them) from any regular expression value condition when generating the query.