### PR TITLE
Custom stream selectors pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,13 @@ This is the Loki backend for pySigma. It provides the package `sigma.backends.lo
 
 It supports the following output formats:
 
-* default: plain Loki LogQL queries
-* ruler: creates Loki LogQL queries in the ruler (YAML) format for generating alerts
+* `default`: plain Loki LogQL queries
+* `ruler`: creates Loki LogQL queries in the ruler (YAML) format for generating alerts
+
+It includes new Loki-specific pipeline transformations:
+
+* `SetLokiStreamSelectionTransform`: adds a `logsource_loki_selection` custom attribute to a rule, which should contain a [stream selector](https://grafana.com/docs/loki/latest/logql/log_queries/#log-stream-selector)  that will be used in the generated query
+* `SetLokiParserTransformation`: adds a `loki_parser` custom attribute to a rule, which should contain a [parser expression](https://grafana.com/docs/loki/latest/logql/log_queries/#parser-expression) that will be used in the generated query
 
 Further, it contains the processing pipelines in `sigma.pipelines.loki`:
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ It supports the following output formats:
 
 It includes new Loki-specific pipeline transformations:
 
-* `SetLokiStreamSelectionTransform`: adds a `logsource_loki_selection` custom attribute to a rule, which should contain a [stream selector](https://grafana.com/docs/loki/latest/logql/log_queries/#log-stream-selector)  that will be used in the generated query
+* `SetLokiStreamSelectionTransform`: adds a `logsource_loki_selection` custom attribute to a rule, which should contain a [stream selector](https://grafana.com/docs/loki/latest/logql/log_queries/#log-stream-selector) that will be used in the generated query
 * `SetLokiParserTransformation`: adds a `loki_parser` custom attribute to a rule, which should contain a [parser expression](https://grafana.com/docs/loki/latest/logql/log_queries/#parser-expression) that will be used in the generated query
 
 Further, it contains the processing pipelines in `sigma.pipelines.loki`:
 
-* loki\_log\_parser: converts field names to logfmt labels used by Grafana
-* loki\_promtail\_sysmon\_message: parse and adjust field names for Windows sysmon data produced by promtail
+* `loki_log_parser`: converts field names to logfmt labels used by Grafana
+* `loki_promtail_sysmon_message`: parse and adjust field names for Windows sysmon data produced by promtail
   * Note: most rules lack the `sysmon` service tag, and hence this pipeline should be used in combination with the [generic sysmon pipeline](https://github.com/SigmaHQ/pySigma-pipeline-sysmon)
 
 This backend is currently maintained by:

--- a/sigma/backends/loki/__init__.py
+++ b/sigma/backends/loki/__init__.py
@@ -1,1 +1,4 @@
-from .loki import LogQLBackend  # noqa: F401
+from .loki import LogQLBackend
+
+
+__all__ = ("LogQLBackend",)

--- a/sigma/backends/loki/loki.py
+++ b/sigma/backends/loki/loki.py
@@ -279,8 +279,8 @@ class LogQLBackend(TextQueryBackend):
         """Select a relevant log parser based on common approaches to ingesting data into Loki.
         Currently defaults to logfmt, but will use the json parser for Windows, Azure and Zeek
         signatures."""
-        if str(LokiCustomAttrs.PARSER) in rule.custom_attributes:
-            return rule.custom_attributes[str(LokiCustomAttrs.PARSER)]
+        if LokiCustomAttrs.PARSER.value in rule.custom_attributes:
+            return rule.custom_attributes[LokiCustomAttrs.PARSER.value]
         # TODO: this currently supports two commonly used formats -
         # more advanced parser formats would be required/more efficient for other sources
         if rule.logsource.product in ("windows", "azure", "zeek"):
@@ -303,8 +303,8 @@ class LogQLBackend(TextQueryBackend):
     def select_log_stream(self, rule: SigmaRule) -> str:
         """Select a logstream based on the logsource information included within a rule and
         following the assumptions described in select_log_parser."""
-        if str(LokiCustomAttrs.LOGSOURCE_SELECTION) in rule.custom_attributes:
-            return rule.custom_attributes[str(LokiCustomAttrs.LOGSOURCE_SELECTION)]
+        if LokiCustomAttrs.LOGSOURCE_SELECTION.value in rule.custom_attributes:
+            return rule.custom_attributes[LokiCustomAttrs.LOGSOURCE_SELECTION.value]
         logsource = rule.logsource
         if logsource.product == "windows":
             return '{job=~"eventlog|winlog|windows|fluentbit.*"}'

--- a/sigma/backends/loki/loki.py
+++ b/sigma/backends/loki/loki.py
@@ -279,8 +279,8 @@ class LogQLBackend(TextQueryBackend):
         """Select a relevant log parser based on common approaches to ingesting data into Loki.
         Currently defaults to logfmt, but will use the json parser for Windows, Azure and Zeek
         signatures."""
-        if LokiCustomAttrs.PARSER in rule.custom_attributes:
-            return rule.custom_attributes[LokiCustomAttrs.PARSER]
+        if str(LokiCustomAttrs.PARSER) in rule.custom_attributes:
+            return rule.custom_attributes[str(LokiCustomAttrs.PARSER)]
         # TODO: this currently supports two commonly used formats -
         # more advanced parser formats would be required/more efficient for other sources
         if rule.logsource.product in ("windows", "azure", "zeek"):
@@ -303,8 +303,8 @@ class LogQLBackend(TextQueryBackend):
     def select_log_stream(self, rule: SigmaRule) -> str:
         """Select a logstream based on the logsource information included within a rule and
         following the assumptions described in select_log_parser."""
-        if LokiCustomAttrs.LOGSOURCE_SELECTION in rule.custom_attributes:
-            return rule.custom_attributes[LokiCustomAttrs.LOGSOURCE_SELECTION]
+        if str(LokiCustomAttrs.LOGSOURCE_SELECTION) in rule.custom_attributes:
+            return rule.custom_attributes[str(LokiCustomAttrs.LOGSOURCE_SELECTION)]
         logsource = rule.logsource
         if logsource.product == "windows":
             return '{job=~"eventlog|winlog|windows|fluentbit.*"}'

--- a/sigma/backends/loki/loki.py
+++ b/sigma/backends/loki/loki.py
@@ -30,6 +30,7 @@ from sigma.conversion.base import TextQueryBackend
 from sigma.conversion.deferred import DeferredQueryExpression
 from sigma.conversion.state import ConversionState
 from sigma.exceptions import SigmaFeatureNotSupportedByBackendError, SigmaError
+from sigma.pipelines.loki import LokiCustomAttrs
 from sigma.rule import SigmaRule
 from sigma.types import (
     SigmaBool,
@@ -278,8 +279,8 @@ class LogQLBackend(TextQueryBackend):
         """Select a relevant log parser based on common approaches to ingesting data into Loki.
         Currently defaults to logfmt, but will use the json parser for Windows, Azure and Zeek
         signatures."""
-        if "loki_parser" in rule.custom_attributes:
-            return rule.custom_attributes["loki_parser"]
+        if LokiCustomAttrs.PARSER in rule.custom_attributes:
+            return rule.custom_attributes[LokiCustomAttrs.PARSER]
         # TODO: this currently supports two commonly used formats -
         # more advanced parser formats would be required/more efficient for other sources
         if rule.logsource.product in ("windows", "azure", "zeek"):
@@ -302,8 +303,8 @@ class LogQLBackend(TextQueryBackend):
     def select_log_stream(self, rule: SigmaRule) -> str:
         """Select a logstream based on the logsource information included within a rule and
         following the assumptions described in select_log_parser."""
-        if "logsource_loki_selection" in rule.custom_attributes:
-            return rule.custom_attributes["logsource_loki_selection"]
+        if LokiCustomAttrs.LOGSOURCE_SELECTION in rule.custom_attributes:
+            return rule.custom_attributes[LokiCustomAttrs.LOGSOURCE_SELECTION]
         logsource = rule.logsource
         if logsource.product == "windows":
             return '{job=~"eventlog|winlog|windows|fluentbit.*"}'

--- a/sigma/pipelines/loki/__init__.py
+++ b/sigma/pipelines/loki/__init__.py
@@ -1,7 +1,16 @@
-from .loki import (  # noqa: F401
+from .loki import (
     LokiCustomAttrs,
     SetLokiParserTransformation,
     SetLokiStreamSelectionTransform,
     loki_grafana_logfmt,
     loki_promtail_sysmon_message,
+)
+
+
+__all__ = (
+    "LokiCustomAttrs",
+    "SetLokiParserTransformation",
+    "SetLokiStreamSelectionTransform",
+    "loki_grafana_logfmt",
+    "loki_promtail_sysmon_message",
 )

--- a/sigma/pipelines/loki/__init__.py
+++ b/sigma/pipelines/loki/__init__.py
@@ -1,4 +1,5 @@
 from .loki import (  # noqa: F401
+    LokiCustomAttrs,
     SetLokiParserTransformation,
     SetLokiStreamSelectionTransform,
     loki_grafana_logfmt,

--- a/sigma/pipelines/loki/__init__.py
+++ b/sigma/pipelines/loki/__init__.py
@@ -1,5 +1,6 @@
 from .loki import (  # noqa: F401
     SetLokiParserTransformation,
+    SetLokiStreamSelectionTransform,
     loki_grafana_logfmt,
     loki_promtail_sysmon_message,
 )

--- a/sigma/pipelines/loki/loki.py
+++ b/sigma/pipelines/loki/loki.py
@@ -13,9 +13,6 @@ class LokiCustomAttrs(Enum):
     PARSER = "loki_parser"
     LOGSOURCE_SELECTION = "logsource_loki_selection"
 
-    def __str__(self):
-        return self.value
-
 
 @dataclass
 class SetLokiParserTransformation(Transformation):
@@ -26,7 +23,7 @@ class SetLokiParserTransformation(Transformation):
 
     def apply(self, pipeline: ProcessingPipeline, rule: SigmaRule) -> None:
         super().apply(pipeline, rule)
-        rule.custom_attributes[str(LokiCustomAttrs.PARSER)] = self.parser
+        rule.custom_attributes[LokiCustomAttrs.PARSER.value] = self.parser
 
 
 @dataclass
@@ -43,7 +40,7 @@ class SetLokiStreamSelectionTransform(Transformation):
     def apply(self, pipeline: ProcessingPipeline, rule: SigmaRule) -> None:
         super().apply(pipeline, rule)
         rule.custom_attributes[
-            str(LokiCustomAttrs.LOGSOURCE_SELECTION)
+            LokiCustomAttrs.LOGSOURCE_SELECTION.value
         ] = self.selection
 
 

--- a/sigma/pipelines/loki/loki.py
+++ b/sigma/pipelines/loki/loki.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Dict
 from sigma.rule import SigmaRule
 from sigma.processing.conditions import LogsourceCondition
 from sigma.processing.pipeline import ProcessingItem, ProcessingPipeline
@@ -15,6 +16,32 @@ class SetLokiParserTransformation(Transformation):
     def apply(self, pipeline: ProcessingPipeline, rule: SigmaRule) -> None:
         super().apply(pipeline, rule)
         rule.custom_attributes["loki_parser"] = self.parser
+
+
+@dataclass
+class SetLokiStreamSelectionTransform(Transformation):
+    """Sets the custom dictionary attribute `logsource-loki-selection` to define a more precise
+    stream selector for Loki. Those values are interpreted as a single map Search-Identifier is
+    within a `detection` attribute (restricted to no undefined fields and only permitting the
+    `re` and `contains` modifiers).
+
+    Example selection:
+        {"job": "mylogs", "filename|re": ".*[\\d]+.log$"}
+
+    Output Rule YAML:
+        logsource-loki-selection:
+          job: mylogs
+          filename|re: .*[\\d]+.log$
+
+    Output LogQL stream selector:
+        {job=`mylogs`,filename=~`.*[\\d]+.log$`}
+    """
+
+    selection: Dict[str, str]
+
+    def apply(self, pipeline: ProcessingPipeline, rule: SigmaRule) -> None:
+        super().apply(pipeline, rule)
+        rule.custom_attributes["logsource-loki-selection"] = self.selection
 
 
 def loki_grafana_logfmt() -> ProcessingPipeline:

--- a/sigma/pipelines/loki/loki.py
+++ b/sigma/pipelines/loki/loki.py
@@ -1,8 +1,20 @@
 from dataclasses import dataclass
+from enum import Enum
 from sigma.rule import SigmaRule
 from sigma.processing.conditions import LogsourceCondition
 from sigma.processing.pipeline import ProcessingItem, ProcessingPipeline
 from sigma.processing.transformations import Transformation, FieldMappingTransformation
+
+
+class LokiCustomAttrs(Enum):
+    """The different custom attributes used by pipelines to store additional Loki-specific
+    functionality."""
+
+    PARSER = "loki_parser"
+    LOGSOURCE_SELECTION = "logsource_loki_selection"
+
+    def __str__(self):
+        return self.value
 
 
 @dataclass
@@ -14,7 +26,7 @@ class SetLokiParserTransformation(Transformation):
 
     def apply(self, pipeline: ProcessingPipeline, rule: SigmaRule) -> None:
         super().apply(pipeline, rule)
-        rule.custom_attributes["loki_parser"] = self.parser
+        rule.custom_attributes[LokiCustomAttrs.PARSER] = self.parser
 
 
 @dataclass
@@ -30,7 +42,7 @@ class SetLokiStreamSelectionTransform(Transformation):
 
     def apply(self, pipeline: ProcessingPipeline, rule: SigmaRule) -> None:
         super().apply(pipeline, rule)
-        rule.custom_attributes["logsource_loki_selection"] = self.selection
+        rule.custom_attributes[LokiCustomAttrs.LOGSOURCE_SELECTION] = self.selection
 
 
 def loki_grafana_logfmt() -> ProcessingPipeline:

--- a/sigma/pipelines/loki/loki.py
+++ b/sigma/pipelines/loki/loki.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Dict
 from sigma.rule import SigmaRule
 from sigma.processing.conditions import LogsourceCondition
 from sigma.processing.pipeline import ProcessingItem, ProcessingPipeline
@@ -20,24 +19,14 @@ class SetLokiParserTransformation(Transformation):
 
 @dataclass
 class SetLokiStreamSelectionTransform(Transformation):
-    """Sets the custom map attribute `logsource_loki_selection` to define a more precise stream
-    selector for Loki. Those values are interpreted as a single map Search-Identifier is
-    within a `detection` attribute (restricted to no undefined fields and only permitting the
-    `contains`, `re`, `endswith`, `startswith`  modifiers).
+    """Sets the custom attribute `logsource_loki_selection` to define a more precise stream
+    selector for Loki.
 
     Example selection:
-        {"job": "mylogs", "filename|re": ".*[\\d]+.log$"}
-
-    Output Rule YAML:
-        logsource_loki_selection:
-          job: mylogs
-          filename|re: .*[\\d]+.log$
-
-    Output LogQL stream selector:
         {job=`mylogs`,filename=~`.*[\\d]+.log$`}
     """
 
-    selection: Dict[str, str]
+    selection: str
 
     def apply(self, pipeline: ProcessingPipeline, rule: SigmaRule) -> None:
         super().apply(pipeline, rule)

--- a/sigma/pipelines/loki/loki.py
+++ b/sigma/pipelines/loki/loki.py
@@ -20,16 +20,16 @@ class SetLokiParserTransformation(Transformation):
 
 @dataclass
 class SetLokiStreamSelectionTransform(Transformation):
-    """Sets the custom dictionary attribute `logsource-loki-selection` to define a more precise
-    stream selector for Loki. Those values are interpreted as a single map Search-Identifier is
+    """Sets the custom map attribute `logsource_loki_selection` to define a more precise stream
+    selector for Loki. Those values are interpreted as a single map Search-Identifier is
     within a `detection` attribute (restricted to no undefined fields and only permitting the
-    `re` and `contains` modifiers).
+    `contains`, `re`, `endswith`, `startswith`  modifiers).
 
     Example selection:
         {"job": "mylogs", "filename|re": ".*[\\d]+.log$"}
 
     Output Rule YAML:
-        logsource-loki-selection:
+        logsource_loki_selection:
           job: mylogs
           filename|re: .*[\\d]+.log$
 
@@ -41,7 +41,7 @@ class SetLokiStreamSelectionTransform(Transformation):
 
     def apply(self, pipeline: ProcessingPipeline, rule: SigmaRule) -> None:
         super().apply(pipeline, rule)
-        rule.custom_attributes["logsource-loki-selection"] = self.selection
+        rule.custom_attributes["logsource_loki_selection"] = self.selection
 
 
 def loki_grafana_logfmt() -> ProcessingPipeline:

--- a/sigma/pipelines/loki/loki.py
+++ b/sigma/pipelines/loki/loki.py
@@ -26,7 +26,7 @@ class SetLokiParserTransformation(Transformation):
 
     def apply(self, pipeline: ProcessingPipeline, rule: SigmaRule) -> None:
         super().apply(pipeline, rule)
-        rule.custom_attributes[LokiCustomAttrs.PARSER] = self.parser
+        rule.custom_attributes[str(LokiCustomAttrs.PARSER)] = self.parser
 
 
 @dataclass
@@ -42,7 +42,9 @@ class SetLokiStreamSelectionTransform(Transformation):
 
     def apply(self, pipeline: ProcessingPipeline, rule: SigmaRule) -> None:
         super().apply(pipeline, rule)
-        rule.custom_attributes[LokiCustomAttrs.LOGSOURCE_SELECTION] = self.selection
+        rule.custom_attributes[
+            str(LokiCustomAttrs.LOGSOURCE_SELECTION)
+        ] = self.selection
 
 
 def loki_grafana_logfmt() -> ProcessingPipeline:

--- a/tests/test_backend_loki.py
+++ b/tests/test_backend_loki.py
@@ -1150,6 +1150,29 @@ def test_loki_very_long_query_too_few_or_args(loki_backend: LogQLBackend):
         assert len(test) == 2 and all(len(query) > 5120 for query in test)
 
 
+def test_loki_custom_attrs(loki_backend: LogQLBackend):
+    assert (
+        loki_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            logsource_loki_selection: '{job=`test`}'
+            detection:
+                sel:
+                    fieldA: valueA
+                condition: sel
+            loki_parser: pattern `<ip> <ts> <msg>`
+        """
+            )
+        )
+        == ["{job=`test`} | pattern `<ip> <ts> <msg>` | fieldA=`valueA`"]
+    )
+
+
 # Tests for unimplemented/unsupported features
 def test_loki_unbound_or_field(loki_backend: LogQLBackend):
     with pytest.raises(SigmaFeatureNotSupportedByBackendError):

--- a/tests/test_pipelines_loki.py
+++ b/tests/test_pipelines_loki.py
@@ -3,6 +3,7 @@ from sigma.collection import SigmaCollection
 from sigma.processing.pipeline import ProcessingItem, ProcessingPipeline
 from sigma.pipelines.loki import (
     SetLokiParserTransformation,
+    SetLokiStreamSelectionTransform,
     loki_grafana_logfmt,
     loki_promtail_sysmon_message,
 )
@@ -89,3 +90,36 @@ def test_loki_parser_pipeline():
     )
     loki_rule = backend.convert(sigma_rule)
     assert loki_rule == ['{job=~".+"} | pattern `<ip> <ts> <msg>` | msg=`testing`']
+
+
+def test_loki_logsource_selection_pipeline():
+    pipeline = ProcessingPipeline(
+        name="Test custom Loki logsource pipeline",
+        priority=20,
+        items=[
+            ProcessingItem(
+                identifier="set_loki_logsource_selection",
+                transformation=SetLokiStreamSelectionTransform(
+                    {"job": "mylogs", "filename|re": ".*[\\d]+.log$"}
+                ),
+            )
+        ],
+    )
+    backend = LogQLBackend(processing_pipeline=pipeline)
+    sigma_rule = SigmaCollection.from_yaml(
+        """
+            title: Test
+            status: test
+            logsource:
+                product: test
+                service: test
+            detection:
+                sel:
+                    msg: testing
+                condition: sel
+        """
+    )
+    loki_rule = backend.convert(sigma_rule)
+    assert loki_rule == [
+        "{job=`mylogs`, filename=~`.*[\\d]+.log$`} | logfmt | msg=`testing`"
+    ]

--- a/tests/test_pipelines_loki.py
+++ b/tests/test_pipelines_loki.py
@@ -100,7 +100,7 @@ def test_loki_logsource_selection_pipeline():
             ProcessingItem(
                 identifier="set_loki_logsource_selection",
                 transformation=SetLokiStreamSelectionTransform(
-                    {"job": "mylogs", "filename|re": ".*[\\d]+.log$"}
+                    "{job=`mylogs`,filename=~`.*[\\d]+.log$`}"
                 ),
             )
         ],
@@ -121,5 +121,5 @@ def test_loki_logsource_selection_pipeline():
     )
     loki_rule = backend.convert(sigma_rule)
     assert loki_rule == [
-        "{job=`mylogs`, filename=~`.*[\\d]+.log$`} | logfmt | msg=`testing`"
+        "{job=`mylogs`,filename=~`.*[\\d]+.log$`} | logfmt | msg=`testing`"
     ]


### PR DESCRIPTION
Adds a new Loki-specific pipeline to allow users to specify a more precise stream selector in the generated query. Originally I had designs on making this very generic and using the same structure as used in a Sigma detection - but the overall benefits appeared limited compared to the ease of just using a string that contains the new stream selector - it seems unlikely to me that other backends would need/be able to use this feature.

Added a couple of additional improvements like using enums for custom_attributes and a few more tests around the use of custom attributes.