### PR TITLE
Custom attributes refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ It supports the following output formats:
 * `default`: plain Loki LogQL queries
 * `ruler`: creates Loki LogQL queries in the ruler (YAML) format for generating alerts
 
-It includes new Loki-specific pipeline transformations:
+It includes the following pipeline transformations:
 
-* `SetLokiStreamSelectionTransform`: adds a `logsource_loki_selection` custom attribute to a rule, which should contain a [stream selector](https://grafana.com/docs/loki/latest/logql/log_queries/#log-stream-selector) that will be used in the generated query
-* `SetLokiParserTransformation`: adds a `loki_parser` custom attribute to a rule, which should contain a [parser expression](https://grafana.com/docs/loki/latest/logql/log_queries/#parser-expression) that will be used in the generated query
+* `SetCustomAttributeTransformation`: adds a specified custom attribute to a rule, which can be used to introduce a [stream selector](https://grafana.com/docs/loki/latest/logql/log_queries/#log-stream-selector) or [parser expression](https://grafana.com/docs/loki/latest/logql/log_queries/#parser-expression) into the generated query
+  * The `sigma.pipelines.loki.LokiCustomAttributes` enum contains the relevant custom attribute names used by the backend
 
 Further, it contains the processing pipelines in `sigma.pipelines.loki`:
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ It supports the following output formats:
 * `default`: plain Loki LogQL queries
 * `ruler`: creates Loki LogQL queries in the ruler (YAML) format for generating alerts
 
-It includes the following pipeline transformations:
+It includes the following pipeline transformations in `sigma.pipelines.loki`:
 
 * `SetCustomAttributeTransformation`: adds a specified custom attribute to a rule, which can be used to introduce a [stream selector](https://grafana.com/docs/loki/latest/logql/log_queries/#log-stream-selector) or [parser expression](https://grafana.com/docs/loki/latest/logql/log_queries/#parser-expression) into the generated query
-  * The `sigma.pipelines.loki.LokiCustomAttributes` enum contains the relevant custom attribute names used by the backend
+  * The `LokiCustomAttributes` enum contains the relevant custom attribute names used by the backend
 
 Further, it contains the processing pipelines in `sigma.pipelines.loki`:
 

--- a/sigma/backends/loki/loki.py
+++ b/sigma/backends/loki/loki.py
@@ -30,7 +30,7 @@ from sigma.conversion.base import TextQueryBackend
 from sigma.conversion.deferred import DeferredQueryExpression
 from sigma.conversion.state import ConversionState
 from sigma.exceptions import SigmaFeatureNotSupportedByBackendError, SigmaError
-from sigma.pipelines.loki import LokiCustomAttrs
+from sigma.pipelines.loki import LokiCustomAttributes
 from sigma.rule import SigmaRule
 from sigma.types import (
     SigmaBool,
@@ -279,8 +279,8 @@ class LogQLBackend(TextQueryBackend):
         """Select a relevant log parser based on common approaches to ingesting data into Loki.
         Currently defaults to logfmt, but will use the json parser for Windows, Azure and Zeek
         signatures."""
-        if LokiCustomAttrs.PARSER.value in rule.custom_attributes:
-            return rule.custom_attributes[LokiCustomAttrs.PARSER.value]
+        if LokiCustomAttributes.PARSER.value in rule.custom_attributes:
+            return rule.custom_attributes[LokiCustomAttributes.PARSER.value]
         # TODO: this currently supports two commonly used formats -
         # more advanced parser formats would be required/more efficient for other sources
         if rule.logsource.product in ("windows", "azure", "zeek"):
@@ -303,8 +303,10 @@ class LogQLBackend(TextQueryBackend):
     def select_log_stream(self, rule: SigmaRule) -> str:
         """Select a logstream based on the logsource information included within a rule and
         following the assumptions described in select_log_parser."""
-        if LokiCustomAttrs.LOGSOURCE_SELECTION.value in rule.custom_attributes:
-            return rule.custom_attributes[LokiCustomAttrs.LOGSOURCE_SELECTION.value]
+        if LokiCustomAttributes.LOGSOURCE_SELECTION.value in rule.custom_attributes:
+            return rule.custom_attributes[
+                LokiCustomAttributes.LOGSOURCE_SELECTION.value
+            ]
         logsource = rule.logsource
         if logsource.product == "windows":
             return '{job=~"eventlog|winlog|windows|fluentbit.*"}'

--- a/sigma/pipelines/loki/__init__.py
+++ b/sigma/pipelines/loki/__init__.py
@@ -1,16 +1,14 @@
 from .loki import (
-    LokiCustomAttrs,
-    SetLokiParserTransformation,
-    SetLokiStreamSelectionTransform,
+    LokiCustomAttributes,
+    SetCustomAttributeTransformation,
     loki_grafana_logfmt,
     loki_promtail_sysmon_message,
 )
 
 
 __all__ = (
-    "LokiCustomAttrs",
-    "SetLokiParserTransformation",
-    "SetLokiStreamSelectionTransform",
+    "LokiCustomAttributes",
+    "SetCustomAttributeTransformation",
     "loki_grafana_logfmt",
     "loki_promtail_sysmon_message",
 )

--- a/tests/test_pipelines_loki.py
+++ b/tests/test_pipelines_loki.py
@@ -1,12 +1,18 @@
 from sigma.backends.loki import LogQLBackend
 from sigma.collection import SigmaCollection
+from sigma.processing.transformations import transformations
 from sigma.processing.pipeline import ProcessingItem, ProcessingPipeline
 from sigma.pipelines.loki import (
-    SetLokiParserTransformation,
-    SetLokiStreamSelectionTransform,
+    LokiCustomAttributes,
+    SetCustomAttributeTransformation,
     loki_grafana_logfmt,
     loki_promtail_sysmon_message,
 )
+
+
+def test_transformations_contains_custom_attribute():
+    assert "set_custom_attribute" in transformations
+    assert transformations["set_custom_attribute"] == SetCustomAttributeTransformation
 
 
 def test_loki_grafana_pipeline():
@@ -68,8 +74,9 @@ def test_loki_parser_pipeline():
         items=[
             ProcessingItem(
                 identifier="set_loki_parser_pattern",
-                transformation=SetLokiParserTransformation(
-                    parser="pattern `<ip> <ts> <msg>`"
+                transformation=SetCustomAttributeTransformation(
+                    attribute=LokiCustomAttributes.PARSER.value,
+                    value="pattern `<ip> <ts> <msg>`",
                 ),
             )
         ],
@@ -99,8 +106,9 @@ def test_loki_logsource_selection_pipeline():
         items=[
             ProcessingItem(
                 identifier="set_loki_logsource_selection",
-                transformation=SetLokiStreamSelectionTransform(
-                    "{job=`mylogs`,filename=~`.*[\\d]+.log$`}"
+                transformation=SetCustomAttributeTransformation(
+                    attribute=LokiCustomAttributes.LOGSOURCE_SELECTION.value,
+                    value="{job=`mylogs`,filename=~`.*[\\d]+.log$`}",
                 ),
             )
         ],

--- a/tests/test_pipelines_loki.py
+++ b/tests/test_pipelines_loki.py
@@ -131,3 +131,48 @@ def test_loki_logsource_selection_pipeline():
     assert loki_rule == [
         "{job=`mylogs`,filename=~`.*[\\d]+.log$`} | logfmt | msg=`testing`"
     ]
+
+
+def test_processing_pipeline_custom_attribute_from_dict():
+    pipeline_dict = {
+        "name": "Testing Custom Pipeline",
+        "vars": {},
+        "priority": 10,
+        "transformations": [
+            {
+                "id": "custom_pipeline_dict",
+                "type": "set_custom_attribute",
+                "rule_conditions": [{"type": "logsource", "category": "web"}],
+                "detection_item_conditions": [
+                    {"type": "match_string", "cond": "any", "pattern": "test"}
+                ],
+                "field_name_conditions": [
+                    {"type": "include_fields", "fields": ["fieldA", "fieldB"]}
+                ],
+                "rule_cond_op": "or",
+                "detection_item_cond_op": "or",
+                "field_name_cond_op": "or",
+                "rule_cond_not": True,
+                "detection_item_cond_not": True,
+                "field_name_cond_not": True,
+                "attribute": "loki_parser",
+                "value": "json",
+            }
+        ],
+    }
+    processing_pipeline = ProcessingPipeline.from_dict(pipeline_dict)
+    assert processing_pipeline is not None
+    assert processing_pipeline.priority == int(pipeline_dict["priority"])
+    assert len(processing_pipeline.items) == len(pipeline_dict["transformations"])
+    processing_item = processing_pipeline.items[0]
+    assert processing_item is not None
+    assert processing_item.transformation is not None
+    assert isinstance(processing_item.transformation, SetCustomAttributeTransformation)
+    assert (
+        processing_item.transformation.attribute
+        == pipeline_dict["transformations"][0]["attribute"]
+    )
+    assert (
+        processing_item.transformation.value
+        == pipeline_dict["transformations"][0]["value"]
+    )


### PR DESCRIPTION
I realised that the two custom attribute Transformation classes we added were achieving the exact same outcome, just on a different custom attribute key - so for simplicities sake, I re-factored these into a single class - which may be relevant elsewhere going forward.

Also updated the test suite to include an example of a processing pipeline being constructed from a dict with the new class to validate that use-case.