### PR TITLE
Refactor parse tree to improve code clarity

### DIFF
--- a/sigma/backends/loki/loki.py
+++ b/sigma/backends/loki/loki.py
@@ -202,7 +202,7 @@ class LogQLBackend(TextQueryBackend):
         "!~": "|~",
     }
 
-    currentTemplates: ClassVar[Union[bool, None]] = None
+    current_templates: ClassVar[Union[bool, None]] = None
     # Leave this to be set by the below function
     eq_token: ClassVar[str]
     field_null_expression: ClassVar[str]
@@ -212,12 +212,12 @@ class LogQLBackend(TextQueryBackend):
     compare_operators: ClassVar[Dict[SigmaCompareExpression.CompareOperators, str]]
 
     @staticmethod
-    def setExpressionTemplates(negated: bool) -> None:
+    def set_expression_templates(negated: bool) -> None:
         """When converting field expressions, the TextBackend class uses the below
         variables to format the rule. As LogQL applies negation directly via
         expressions, we need to dynamically update these depending on whether the
         expression was negated or not."""
-        if negated == LogQLBackend.currentTemplates:
+        if negated == LogQLBackend.current_templates:
             return  # nothing to do!
         if not negated:
             LogQLBackend.eq_token = "="
@@ -242,7 +242,7 @@ class LogQLBackend(TextQueryBackend):
                 SigmaCompareExpression.CompareOperators.GTE: "<",
             }
         # Cache the state of these variables so we don't keep setting them needlessly
-        LogQLBackend.currentTemplates = negated
+        LogQLBackend.current_templates = negated
 
     # LogQL does not support wildcards, but we convert them to regular expressions
     # Character used as multi-character wildcard (replaced with .*)
@@ -788,7 +788,7 @@ class LogQLBackend(TextQueryBackend):
         """Adjust the expression templates based on whether the condition is negated,
         prior to converting it. Not required for convert_condition_val, as they use
         deferred expressions, which use a different approach."""
-        LogQLBackend.setExpressionTemplates(getattr(cond, "negated", False))
+        LogQLBackend.set_expression_templates(getattr(cond, "negated", False))
         return super().convert_condition_field_eq_val(cond, state)
 
     def convert_condition_val_str(
@@ -846,7 +846,7 @@ class LogQLBackend(TextQueryBackend):
         """Select appropriate condition to join together field values and push down
         negation"""
         is_negated = getattr(cond, "negated", False)
-        LogQLBackend.setExpressionTemplates(is_negated)
+        LogQLBackend.set_expression_templates(is_negated)
         exprs = [
             ConditionFieldEqualsValueExpression(cond.field, value)
             for value in cond.value.values


### PR DESCRIPTION
The Sigma specification includes features that are not directly supported in LogQL (e.g., wildcard strings and NOT operators) but equivalent functionality can be achieved via other means. Previously, this backend made changes to the parse tree "on-the-fly", as they were encountered during the conversion process. This led to bugs, and a lack of certainty about edge cases being covered.

I have now refactored the parse tree modifications (changing strings that contain wildcards into regular expressions and eliminating NOTs via De Morgan's laws) into a single function, that is executed after the pipeline stage. I used a depth-first recursive function, as there will be no infinite depth parse trees (without infinite length inputs anyway 😜), which made it easier to pass the negation state down the relevant sub-trees.

There is one place where the negation state still needs to be actively handled during the rule processing: SigmaExpansion's (such as base64offset token conversion) are converted into OR'd (or AND'd, if negated) equalities as there isn't support for them in the backend - but that conversion doesn't happen until they are encountered. This was handled in [convert_condition_field_eq_expansion](https://github.com/grafana/pySigma-backend-loki/blob/a91ef07e49c61c943eedbff32607011cd0598cc7/sigma/backends/loki/loki.py#L843). 

There was also a significant amount of code that could be removed (~100 lines - 10%!) or simplified thanks to these changes. I imagine there may be other places where more of our custom code could be removed (using the default TextBackend implementation instead), but I wasn't able to immediately identify any more at this point.

Closes #19.