### PR TITLE
Update to pySigma 0.9.4

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -431,19 +431,19 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "2.6.2"
+version = "3.0.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
-    {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
+    {file = "platformdirs-3.0.0-py3-none-any.whl", hash = "sha256:b1d5eb14f221506f50d6604a561f4c5786d9e80355219694a1b244bcd96f4567"},
+    {file = "platformdirs-3.0.0.tar.gz", hash = "sha256:8a1228abb1ef82d788f74139988b137e78692984ec7b08eaa6c65f1723af28f9"},
 ]
 
 [package.extras]
-docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"
@@ -502,14 +502,14 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pysigma"
-version = "0.9.0"
+version = "0.9.4"
 description = "Sigma rule processing and conversion tools"
 category = "main"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "pysigma-0.9.0-py3-none-any.whl", hash = "sha256:3089e7986dcd1e7b5ee1fefabdaee4afe1e32fb408392649e28e2c5447b83761"},
-    {file = "pysigma-0.9.0.tar.gz", hash = "sha256:532875a76cd5d3674092f0828fa02cf07de28a4b51fe8e4625ac9fd4133b192c"},
+    {file = "pysigma-0.9.4-py3-none-any.whl", hash = "sha256:aedcc74ca2f66315ed74a181bad8e0601573f646247e2119d06dfcce31105eba"},
+    {file = "pysigma-0.9.4.tar.gz", hash = "sha256:85f6ab825626fda1401f05c481323664fdd93885deb5bf09b5eeff9385caf81f"},
 ]
 
 [package.dependencies]
@@ -699,14 +699,14 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.4.0"
+version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
-    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+    {file = "typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},
+    {file = "typing_extensions-4.5.0.tar.gz", hash = "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb"},
 ]
 
 [[package]]
@@ -729,4 +729,4 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "8e941a0b22f846a779079d201f3f6ab257ed5ac84d56fe99c96fdc57c14e034e"
+content-hash = "128873f2e1186d450eeb73619cbf40f0cd06d7d89e345b7c4c281ba7ce73bb8b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pysigma = "^0.9.0"
+pysigma = "^0.9.4"
 pysigma-pipeline-sysmon = "^1.0.1"
 
 [tool.poetry.dev-dependencies]

--- a/sigma/backends/loki/loki.py
+++ b/sigma/backends/loki/loki.py
@@ -266,7 +266,7 @@ class LogQLBackend(TextQueryBackend):
     deferred_only_query: ClassVar[str] = ""
 
     # Loki-specific functionality
-    add_line_filters: ClassVar[bool] = False
+    add_line_filters: bool = False
 
     def __init__(
         self,


### PR DESCRIPTION
The [latest update to pySigma](https://github.com/SigmaHQ/pySigma/releases/tag/v0.9.4) made a small but impactful modifications to how backend-specific variables are handled (previously pySigma collected these itself in the Backend `__init__` method and provided them in a `config` instance attribute, now each Backend must collect such custom variables in their own `__init__` methods) - so this needed to be updated in our backend to behave correctly given the new approach.

Arguably, this is a non-backwards compatible change, but since [our pyproject.toml specifies the precise pysigma version](https://github.com/grafana/pySigma-backend-loki/blob/84d986ad3a4e8b7e11e6395f1decd8ac7231ffd1/pyproject.toml#L15) we support, it's impact seems limited to me.