### PR TITLE
Fix pipeline resolver issue

### DIFF
--- a/sigma/backends/loki/__init__.py
+++ b/sigma/backends/loki/__init__.py
@@ -1,8 +1,6 @@
 from .loki import LogQLBackend
 
-__all__ = (
-    "LogQLBackend",
-)
+__all__ = ("LogQLBackend",)
 
 backends = {
     "loki": LogQLBackend,

--- a/sigma/backends/loki/__init__.py
+++ b/sigma/backends/loki/__init__.py
@@ -1,5 +1,8 @@
 from .loki import LogQLBackend
 
+__all__ = (
+    "LogQLBackend",
+)
 
 backends = {
     "loki": LogQLBackend,

--- a/sigma/pipelines/loki/__init__.py
+++ b/sigma/pipelines/loki/__init__.py
@@ -6,9 +6,7 @@ from .loki import (
 )
 
 
-__all__ = (
-    "LokiCustomAttributes",
-    "SetCustomAttributeTransformation",
-    "loki_grafana_logfmt",
-    "loki_promtail_sysmon_message",
-)
+pipelines = {
+    "loki": loki_grafana_logfmt,
+    "generic": loki_promtail_sysmon_message,
+}

--- a/sigma/pipelines/loki/__init__.py
+++ b/sigma/pipelines/loki/__init__.py
@@ -5,8 +5,14 @@ from .loki import (
     loki_promtail_sysmon_message,
 )
 
+__all__ = (
+    "LokiCustomAttributes",
+    "SetCustomAttributeTransformation",
+    "loki_grafana_logfmt",
+    "loki_promtail_sysmon_message",
+)
 
 pipelines = {
-    "loki": loki_grafana_logfmt,
-    "generic": loki_promtail_sysmon_message,
+    "loki_grafana_logfmt": loki_grafana_logfmt,
+    "loki_promtail_sysmon": loki_promtail_sysmon_message,
 }

--- a/sigma/pipelines/loki/loki.py
+++ b/sigma/pipelines/loki/loki.py
@@ -39,6 +39,7 @@ def loki_grafana_logfmt() -> ProcessingPipeline:
     return ProcessingPipeline(
         name="Loki Grafana logfmt field names",
         priority=20,
+        allowed_backends=frozenset({"loki"}),
         items=[
             ProcessingItem(
                 identifier="loki_grafana_field_mapping",
@@ -64,7 +65,7 @@ def loki_promtail_sysmon_message() -> ProcessingPipeline:
     return ProcessingPipeline(
         name="Loki Promtail Windows Sysmon Message Parser",
         priority=20,
-        allowed_backends=["loki"],
+        allowed_backends=frozenset({"loki"}),
         items=[
             ProcessingItem(
                 identifier="loki_promtail_sysmon_field_mapping",


### PR DESCRIPTION
This PR adds a fix that caused the PipelineResolver in pysigma not to pick up Loki pipelines when enumerating over all the pipelines.