### PR TITLE
Okta processing pipeline

### DIFF
--- a/sigma/pipelines/loki/__init__.py
+++ b/sigma/pipelines/loki/__init__.py
@@ -3,6 +3,7 @@ from .loki import (
     SetCustomAttributeTransformation,
     loki_grafana_logfmt,
     loki_promtail_sysmon_message,
+    loki_okta_system_log_json,
 )
 
 __all__ = (
@@ -10,9 +11,11 @@ __all__ = (
     "SetCustomAttributeTransformation",
     "loki_grafana_logfmt",
     "loki_promtail_sysmon_message",
+    "loki_okta_system_log_json",
 )
 
 pipelines = {
     "loki_grafana_logfmt": loki_grafana_logfmt,
     "loki_promtail_sysmon": loki_promtail_sysmon_message,
+    "loki_okta_system_log": loki_okta_system_log_json,
 }

--- a/sigma/pipelines/loki/loki.py
+++ b/sigma/pipelines/loki/loki.py
@@ -163,6 +163,7 @@ def loki_okta_system_log_json() -> ProcessingPipeline:
                             "debugContext_debugData_originalPrincipal_alternateId",
                             "debugContext_debugData_originalPrincipal_displayName",
                             "authenticationContext_authenticationProvider",
+                            "authenticationContext_authenticationStep",
                             "authenticationContext_credentialProvider",
                             "authenticationContext_credentialType",
                             "authenticationContext_issuer_id",

--- a/tests/test_pipelines_loki.py
+++ b/tests/test_pipelines_loki.py
@@ -84,6 +84,7 @@ def test_okta_json_pipeline():
                         - policy.lifecycle.update
                         - policy.lifecycle.delete
                     legacyeventtype: 'core.user_auth.login_failed'
+                    displaymessage: 'Failed login to Okta'
                 condition: sel
         """
     )
@@ -91,7 +92,8 @@ def test_okta_json_pipeline():
     assert loki_rule == [
         '{job=~".+"} | json | (event_eventType=`policy.lifecycle.update` or '
         "event_eventType=`policy.lifecycle.delete`) and "
-        "event_legacyEventType=`core.user_auth.login_failed`"
+        "event_legacyEventType=`core.user_auth.login_failed` and "
+        "event_displayMessage=`Failed login to Okta`"
     ]
 
 


### PR DESCRIPTION
When [Okta System Log data](https://developer.okta.com/docs/reference/api/system-log/#get-started) is ingested into Loki, it is generally ingested as raw JSON data, and appearing within a top-level "event" object. In addition, the Sigma rules that target this log data use field names that are entirely lower-case, whilst Loki preserves the camelCase of them.

To resolve these discrepancies, this PR adds a new pipeline to the backend which sets the parser for the generated query appropriately, maps the affected field names into camelCase, and appends `event_` to all field names.