### PR TITLE
Ensure author name is included in alert

### DIFF
--- a/sigma/backends/loki/loki.py
+++ b/sigma/backends/loki/loki.py
@@ -954,6 +954,8 @@ class LogQLBackend(TextQueryBackend):
             "expr": f"sum(count_over_time({query} [1m])) or vector(0) > 0",
             "labels": {},
         }
+        if rule.author:
+            ruler["annotations"]["author"] = rule.author
         if rule.level:
             ruler["labels"]["severity"] = rule.level.name.lower()  # type: ignore
         return ruler

--- a/tests/test_backend_loki.py
+++ b/tests/test_backend_loki.py
@@ -1257,3 +1257,40 @@ def test_loki_ruler_output(loki_backend: LogQLBackend):
       severity: low
 """
     )
+
+
+def test_loki_ruler_author_output(loki_backend: LogQLBackend):
+    """Test for output format ruler."""
+    assert (
+        loki_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: test signature
+            status: test
+            author: test author
+            level: low
+            description: testing
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                keyword:
+                    anything
+                condition: keyword
+        """
+            ),
+            "ruler",
+        )
+        == """groups:
+- name: Sigma rules
+  rules:
+  - alert: test_signature
+    annotations:
+      author: test author
+      description: testing
+      summary: test signature
+    expr: sum(count_over_time({job=~".+"} |= `anything` [1m])) or vector(0) > 0
+    labels:
+      severity: low
+"""
+    )


### PR DESCRIPTION
When converting a rule into an alert, include the author of the rule in the alert configuration by default.