### PR TITLE
Fix latest test generating case-insensitive query

### DIFF
--- a/tests/test_backend_loki.py
+++ b/tests/test_backend_loki.py
@@ -1297,7 +1297,8 @@ def test_loki_ruler_author_output(loki_backend: LogQLBackend):
       author: test author
       description: testing
       summary: test signature
-    expr: sum(count_over_time({job=~".+"} |= `anything` [1m])) or vector(0) > 0
+    expr: sum(count_over_time({job=~".+"} |~ `(?i)anything` [1m])) or vector(0) >
+      0
     labels:
       severity: low
 """


### PR DESCRIPTION
Oops, added a test between defaulting all queries to use case-insensitive queries and now - which of course did not pass (the test expected the old behaviour).