### PR TITLE
Add missing `last_processing_pipeline` property to backend class initialization

### DIFF
--- a/sigma/backends/loki/loki.py
+++ b/sigma/backends/loki/loki.py
@@ -293,6 +293,10 @@ class LogQLBackend(TextQueryBackend):
         case_insensitive: Union[bool, str] = True,
     ):
         super().__init__(processing_pipeline, collect_errors)
+        self.last_processing_pipeline: Optional[
+            ProcessingPipeline
+        ] = processing_pipeline
+
         if isinstance(add_line_filters, bool):
             self.add_line_filters = add_line_filters
         else:


### PR DESCRIPTION
This PR fixes an issue I found while testing the backend using empty `rules`.

## Related
- #82