### PR TITLE
Add auto-mate action to mark tickets as done

### DIFF
--- a/.github/workflows/mark-as-done.yaml
+++ b/.github/workflows/mark-as-done.yaml
@@ -1,0 +1,16 @@
+name: Mark as Done
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  mark-as-done:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move closed issues and merged PRs to the "✅ Done" column
+        uses: grafana/auto-mate@v1
+        with:
+          token: ${{ secrets.AUTO_MATE_TOKEN }}
+          projectNo: 346


### PR DESCRIPTION
This PR adds auto-mate action to mark tickets as done. The tickets can be issues or PRs and they must satisfy these conditions before this action can act on them, otherwise they'll be skipped and the job run fails with errors.

1. Issues MUST be closed when they are in the "Ready For Production" column.
2. PRs MUST be merged when they are in the "Ready For Production" column.

If either of the above conditions apply based on the type of the ticket, the ticket will be moved to the "✅ Done" column whenever a new version is released, i.e. a `v*` tag is pushed.