### PR TITLE
Introduce start and end anchors into label filter regexes

### DIFF
--- a/sigma/backends/loki/loki.py
+++ b/sigma/backends/loki/loki.py
@@ -45,6 +45,7 @@ from sigma.types import (
     SigmaNull,
     SigmaNumber,
     SigmaFieldReference,
+    SpecialChars,
 )
 from warnings import warn
 from yaml import dump
@@ -381,7 +382,9 @@ class LogQLBackend(TextQueryBackend):
         case-insensitive matching"""
         return SigmaRegularExpression(
             ("(?i)" if case_insensitive else "")
+            + ("^" if not value.startswith(SpecialChars.WILDCARD_MULTI) else "")
             + re.escape(str(value)).replace("\\?", ".").replace("\\*", ".*")
+            + ("$" if not value.endswith(SpecialChars.WILDCARD_MULTI) else "")
         )
 
     def select_log_parser(self, rule: SigmaRule) -> Union[str, LogQLLogParser]:

--- a/tests/test_backend_loki.py
+++ b/tests/test_backend_loki.py
@@ -30,7 +30,7 @@ def test_loki_field_eq(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i)valueA`']
+        == ['{job=~".+"} | logfmt | fieldA=~`(?i)^valueA$`']
     )
 
 
@@ -51,7 +51,7 @@ def test_loki_field_eq_tilde(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~"(?i)value`A"']
+        == ['{job=~".+"} | logfmt | fieldA=~"(?i)^value`A$"']
     )
 
 
@@ -72,7 +72,7 @@ def test_loki_field_eq_tilde_double_quote(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~"(?i)v\\"alue`A"']
+        == ['{job=~".+"} | logfmt | fieldA=~"(?i)^v\\"alue`A$"']
     )
 
 
@@ -116,7 +116,7 @@ def test_loki_and_expression(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i)valueA` and fieldB=~`(?i)valueB`']
+        == ['{job=~".+"} | logfmt | fieldA=~`(?i)^valueA$` and fieldB=~`(?i)^valueB$`']
     )
 
 
@@ -139,7 +139,7 @@ def test_loki_or_expression(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i)valueA` or fieldB=~`(?i)valueB`']
+        == ['{job=~".+"} | logfmt | fieldA=~`(?i)^valueA$` or fieldB=~`(?i)^valueB$`']
     )
 
 
@@ -166,8 +166,8 @@ def test_loki_and_or_expression(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} | logfmt | (fieldA=~`(?i)valueA1` or fieldA=~`(?i)valueA2`) and '
-            "(fieldB=~`(?i)valueB1` or fieldB=~`(?i)valueB2`)"
+            '{job=~".+"} | logfmt | (fieldA=~`(?i)^valueA1$` or fieldA=~`(?i)^valueA2$`) and '
+            "(fieldB=~`(?i)^valueB1$` or fieldB=~`(?i)^valueB2$`)"
         ]
     )
 
@@ -194,8 +194,8 @@ def test_loki_or_and_expression(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} | logfmt | fieldA=~`(?i)valueA1` and fieldB=~`(?i)valueB1` or '
-            "fieldA=~`(?i)valueA2` and fieldB=~`(?i)valueB2`"
+            '{job=~".+"} | logfmt | fieldA=~`(?i)^valueA1$` and fieldB=~`(?i)^valueB1$` or '
+            "fieldA=~`(?i)^valueA2$` and fieldB=~`(?i)^valueB2$`"
         ]
     )
 
@@ -222,8 +222,8 @@ def test_loki_in_expression(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} | logfmt | fieldA=~`(?i)valueA` or fieldA=~`(?i)valueB` or '
-            "fieldA=~`(?i)valueC`"
+            '{job=~".+"} | logfmt | fieldA=~`(?i)^valueA$` or fieldA=~`(?i)^valueB$` or '
+            "fieldA=~`(?i)^valueC$`"
         ]
     )
 
@@ -247,7 +247,7 @@ def test_loki_all_query(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i)valueA` and fieldA=~`(?i)valueB`']
+        == ['{job=~".+"} | logfmt | fieldA=~`(?i)^valueA$` and fieldA=~`(?i)^valueB$`']
     )
 
 
@@ -317,7 +317,7 @@ def test_loki_wildcard_single(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i)va.ue`']
+        == ['{job=~".+"} | logfmt | fieldA=~`(?i)^va.ue$`']
     )
 
 
@@ -338,7 +338,7 @@ def test_loki_wildcard_multi(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i)value.*`']
+        == ['{job=~".+"} | logfmt | fieldA=~`(?i)^value.*`']
     )
 
 
@@ -361,29 +361,7 @@ def test_loki_wildcard_escape(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i)\\^v\\)\\+\\[al\\]u\\(e.*\\$`']
-    )
-
-
-def test_loki_cased_query(loki_backend: LogQLBackend):
-    assert (
-        loki_backend.convert(
-            SigmaCollection.from_yaml(
-                """
-            title: Test
-            status: test
-            logsource:
-                category: test_category
-                product: test_product
-            detection:
-                sel:
-                    fieldA|cased: fooBAR
-                    fieldB: fooBAR
-                condition: sel
-        """
-            )
-        )
-        == ['{job=~".+"} | logfmt | fieldA=`fooBAR` and fieldB=~`(?i)fooBAR`']
+        == ['{job=~".+"} | logfmt | fieldA=~`(?i)^\\^v\\)\\+\\[al\\]u\\(e.*\\$$`']
     )
 
 
@@ -405,29 +383,7 @@ def test_loki_cased_unbound_query(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} |= `fooBAR` | logfmt | fieldB=~`(?i)fooBAR`']
-    )
-
-
-def test_loki_regex_query(loki_backend: LogQLBackend):
-    assert (
-        loki_backend.convert(
-            SigmaCollection.from_yaml(
-                """
-            title: Test
-            status: test
-            logsource:
-                category: test_category
-                product: test_product
-            detection:
-                sel:
-                    fieldA|re: foo.*bar
-                    fieldB: foo
-                condition: sel
-        """
-            )
-        )
-        == ['{job=~".+"} | logfmt | fieldA=~`foo.*bar` and fieldB=~`(?i)foo`']
+        == ['{job=~".+"} |= `fooBAR` | logfmt | fieldB=~`(?i)^fooBAR$`']
     )
 
 
@@ -452,132 +408,6 @@ def test_loki_field_re_tilde(loki_backend: LogQLBackend):
     )
 
 
-def test_loki_field_re_tilde_double_quote(loki_backend: LogQLBackend):
-    assert (
-        loki_backend.convert(
-            SigmaCollection.from_yaml(
-                """
-            title: Test
-            status: test
-            logsource:
-                category: test_category
-                product: test_product
-            detection:
-                sel:
-                    fieldA|re: v"alue`A
-                condition: sel
-        """
-            )
-        )
-        == ['{job=~".+"} | logfmt | fieldA=~"v\\"alue`A"']
-    )
-
-
-def test_loki_field_startswith(loki_backend: LogQLBackend):
-    assert (
-        loki_backend.convert(
-            SigmaCollection.from_yaml(
-                """
-            title: Test
-            status: test
-            logsource:
-                category: test_category
-                product: test_product
-            detection:
-                sel:
-                    fieldA|startswith: foo
-                condition: sel
-        """
-            )
-        )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i)foo.*`']
-    )
-
-
-def test_loki_field_endswith(loki_backend: LogQLBackend):
-    assert (
-        loki_backend.convert(
-            SigmaCollection.from_yaml(
-                """
-            title: Test
-            status: test
-            logsource:
-                category: test_category
-                product: test_product
-            detection:
-                sel:
-                    fieldA|endswith: bar
-                condition: sel
-        """
-            )
-        )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i).*bar`']
-    )
-
-
-def test_loki_field_contains(loki_backend: LogQLBackend):
-    assert (
-        loki_backend.convert(
-            SigmaCollection.from_yaml(
-                """
-            title: Test
-            status: test
-            logsource:
-                category: test_category
-                product: test_product
-            detection:
-                sel:
-                    fieldA|contains: ooba
-                condition: sel
-        """
-            )
-        )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i).*ooba.*`']
-    )
-
-
-def test_loki_field_exists(loki_backend: LogQLBackend):
-    assert (
-        loki_backend.convert(
-            SigmaCollection.from_yaml(
-                """
-            title: Test
-            status: test
-            logsource:
-                category: test_category
-                product: test_product
-            detection:
-                sel:
-                    fieldA|exists: yes
-                condition: sel
-        """
-            )
-        )
-        == ['{job=~".+"} | logfmt | fieldA!=""']
-    )
-
-
-def test_loki_field_not_exists(loki_backend: LogQLBackend):
-    assert (
-        loki_backend.convert(
-            SigmaCollection.from_yaml(
-                """
-            title: Test
-            status: test
-            logsource:
-                category: test_category
-                product: test_product
-            detection:
-                sel:
-                    fieldA|exists: no
-                condition: sel
-        """
-            )
-        )
-        == ['{job=~".+"} | logfmt | fieldA=""']
-    )
-
-
 def test_loki_field_cased_startswith(loki_backend: LogQLBackend):
     assert (
         loki_backend.convert(
@@ -595,7 +425,7 @@ def test_loki_field_cased_startswith(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~`foo.*`']
+        == ['{job=~".+"} | logfmt | fieldA=~`^foo.*`']
     )
 
 
@@ -616,7 +446,7 @@ def test_loki_field_cased_endswith(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~`.*bar`']
+        == ['{job=~".+"} | logfmt | fieldA=~`.*bar$`']
     )
 
 
@@ -641,72 +471,6 @@ def test_loki_field_cased_contains(loki_backend: LogQLBackend):
     )
 
 
-def test_loki_cidr_query(loki_backend: LogQLBackend):
-    assert (
-        loki_backend.convert(
-            SigmaCollection.from_yaml(
-                """
-            title: Test
-            status: test
-            logsource:
-                category: test_category
-                product: test_product
-            detection:
-                sel:
-                    fieldA|cidr: 192.168.0.0/16
-                condition: sel
-        """
-            )
-        )
-        == ['{job=~".+"} | logfmt | fieldA=ip("192.168.0.0/16")']
-    )
-
-
-def test_loki_base64_query(loki_backend: LogQLBackend):
-    assert (
-        loki_backend.convert(
-            SigmaCollection.from_yaml(
-                """
-            title: Test
-            status: test
-            logsource:
-                category: test_category
-                product: test_product
-            detection:
-                sel:
-                    fieldA|base64: value
-                condition: sel
-        """
-            )
-        )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i)dmFsdWU=`']
-    )
-
-
-def test_loki_base64offset_query(loki_backend: LogQLBackend):
-    assert (
-        loki_backend.convert(
-            SigmaCollection.from_yaml(
-                """
-            title: Test
-            status: test
-            logsource:
-                category: test_category
-                product: test_product
-            detection:
-                sel:
-                    fieldA|base64offset: value
-                condition: sel
-        """
-            )
-        )
-        == [
-            '{job=~".+"} | logfmt | fieldA=~`(?i)dmFsdW` or fieldA=~`(?i)ZhbHVl` or '
-            "fieldA=~`(?i)2YWx1Z`"
-        ]
-    )
-
-
 def test_loki_field_name_with_whitespace(loki_backend: LogQLBackend):
     assert (
         loki_backend.convert(
@@ -724,7 +488,7 @@ def test_loki_field_name_with_whitespace(loki_backend: LogQLBackend):
           """
             )
         )
-        == ['{job=~".+"} | logfmt | field_name=~`(?i)value`']
+        == ['{job=~".+"} | logfmt | field_name=~`(?i)^value$`']
     )
 
 
@@ -745,7 +509,7 @@ def test_loki_field_name_leading_num(loki_backend: LogQLBackend):
           """
             )
         )
-        == ['{job=~".+"} | logfmt | _0field=~`(?i)value`']
+        == ['{job=~".+"} | logfmt | _0field=~`(?i)^value$`']
     )
 
 
@@ -768,7 +532,7 @@ def test_loki_field_name_empty_whitespace_null(loki_backend: LogQLBackend):
           """
             )
         )
-        == ['{job=~".+"} |~ `(?i)valueA` |~ `(?i)valueB` | logfmt | =~`(?i)valueC`']
+        == ['{job=~".+"} |~ `(?i)valueA` |~ `(?i)valueB` | logfmt | =~`(?i)^valueC$`']
     )
 
 
@@ -789,7 +553,7 @@ def test_loki_field_name_invalid(loki_backend: LogQLBackend):
           """
             )
         )
-        == ['{job=~".+"} | logfmt | field_name_A_Z=~`(?i)value`']
+        == ['{job=~".+"} | logfmt | field_name_A_Z=~`(?i)^value$`']
     )
 
 
@@ -1104,7 +868,7 @@ def test_loki_field_and_unbound(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} |~ `(?i)valueA` | logfmt | fieldA=~`(?i)valueB`']
+        == ['{job=~".+"} |~ `(?i)valueA` | logfmt | fieldA=~`(?i)^valueB$`']
     )
 
 
@@ -1130,7 +894,7 @@ def test_loki_field_and_unbound_group_expression(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} |~ `(?i)valueB` |~ `(?i)valueC` | logfmt | fieldA=~`(?i)valueA`'
+            '{job=~".+"} |~ `(?i)valueB` |~ `(?i)valueC` | logfmt | fieldA=~`(?i)^valueA$`'
         ]
     )
 
@@ -1189,7 +953,7 @@ def test_loki_windows_logsource(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~"eventlog|winlog|windows|fluentbit.*"} | json | key1_key2=~`(?i)value`'
+            '{job=~"eventlog|winlog|windows|fluentbit.*"} | json | key1_key2=~`(?i)^value$`'
         ]
     )
 
@@ -1211,7 +975,7 @@ def test_loki_azure_logsource(loki_backend: LogQLBackend):
           """
             )
         )
-        == ['{job="logstash"} | json | key1_key2=~`(?i)value`']
+        == ['{job="logstash"} | json | key1_key2=~`(?i)^value$`']
     )
 
 
@@ -1237,7 +1001,7 @@ def test_loki_fields(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} | logfmt | fieldA=~`(?i)valueA` and fieldB=~`(?i)valueB` | '
+            '{job=~".+"} | logfmt | fieldA=~`(?i)^valueA$` and fieldB=~`(?i)^valueB$` | '
             'line_format "{{.fieldA}} {{.fieldB}}"'
         ]
     )
@@ -1360,7 +1124,7 @@ def test_loki_custom_attrs(loki_backend: LogQLBackend):
         """
             )
         )
-        == ["{job=~`(?i)test`} | pattern `<ip> <ts> <msg>` | fieldA=~`(?i)valueA`"]
+        == ["{job=~`(?i)test`} | pattern `<ip> <ts> <msg>` | fieldA=~`(?i)^valueA$`"]
     )
 
 

--- a/tests/test_backend_loki_add_line_filters.py
+++ b/tests/test_backend_loki_add_line_filters.py
@@ -75,7 +75,7 @@ def test_loki_lf_field_eq_wildcard(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} |~ `(?i)value.A` | logfmt | fieldA=~`(?i)value.A`']
+        == ['{job=~".+"} |~ `(?i)value.A` | logfmt | fieldA=~`(?i)^value.A$`']
     )
 
 
@@ -96,7 +96,7 @@ def test_loki_lf_field_not_eq_wildcard(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} !~ `(?i)value.A` | logfmt | fieldA!~`(?i)value.A`']
+        == ['{job=~".+"} !~ `(?i)value.A` | logfmt | fieldA!~`(?i)^value.A$`']
     )
 
 
@@ -426,7 +426,7 @@ def test_loki_lf_wildcard_single(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} |~ `(?i)va.ue` | logfmt | fieldA=~`(?i)va.ue`']
+        == ['{job=~".+"} |~ `(?i)va.ue` | logfmt | fieldA=~`(?i)^va.ue$`']
     )
 
 
@@ -447,7 +447,7 @@ def test_loki_lf_wildcard_multi(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} |~ `(?i)value.*` | logfmt | fieldA=~`(?i)value.*`']
+        == ['{job=~".+"} |~ `(?i)value.*` | logfmt | fieldA=~`(?i)^value.*`']
     )
 
 
@@ -472,7 +472,7 @@ def test_loki_lf_wildcard_escape(loki_backend: LogQLBackend):
         )
         == [
             '{job=~".+"} |~ `(?i)\\^v\\)\\+\\[al\\]u\\(e.*\\$` | logfmt | '
-            "fieldA=~`(?i)\\^v\\)\\+\\[al\\]u\\(e.*\\$`"
+            "fieldA=~`(?i)^\\^v\\)\\+\\[al\\]u\\(e.*\\$$`"
         ]
     )
 
@@ -560,7 +560,7 @@ def test_loki_lf_field_startswith(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} |~ `(?i)foo.*` | logfmt | fieldA=~`(?i)foo.*`']
+        == ['{job=~".+"} |~ `(?i)foo.*` | logfmt | fieldA=~`(?i)^foo.*`']
     )
 
 
@@ -581,7 +581,7 @@ def test_loki_lf_field_endswith(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} |~ `(?i).*bar` | logfmt | fieldA=~`(?i).*bar`']
+        == ['{job=~".+"} |~ `(?i).*bar` | logfmt | fieldA=~`(?i).*bar$`']
     )
 
 

--- a/tests/test_backend_loki_add_line_filters_case_insensitive.py
+++ b/tests/test_backend_loki_add_line_filters_case_insensitive.py
@@ -31,7 +31,7 @@ def test_loki_lf_field_eq(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} |~ `(?i)valueA` | logfmt | fieldA=~`(?i)valueA`']
+        == ['{job=~".+"} |~ `(?i)valueA` | logfmt | fieldA=~`(?i)^valueA$`']
     )
 
 
@@ -52,7 +52,7 @@ def test_loki_field_not_eq(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} !~ `(?i)valueA` | logfmt | fieldA!~`(?i)valueA`']
+        == ['{job=~".+"} !~ `(?i)valueA` | logfmt | fieldA!~`(?i)^valueA$`']
     )
 
 
@@ -73,7 +73,7 @@ def test_loki_lf_field_eq_wildcard(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} |~ `(?i)value.A` | logfmt | fieldA=~`(?i)value.A`']
+        == ['{job=~".+"} |~ `(?i)value.A` | logfmt | fieldA=~`(?i)^value.A$`']
     )
 
 
@@ -94,7 +94,7 @@ def test_loki_lf_field_not_eq_wildcard(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} !~ `(?i)value.A` | logfmt | fieldA!~`(?i)value.A`']
+        == ['{job=~".+"} !~ `(?i)value.A` | logfmt | fieldA!~`(?i)^value.A$`']
     )
 
 
@@ -139,8 +139,8 @@ def test_loki_lf_and_expression(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} |~ `(?i)valueA` | logfmt | fieldA=~`(?i)valueA` '
-            "and fieldB=~`(?i)valueB`"
+            '{job=~".+"} |~ `(?i)valueA` | logfmt | fieldA=~`(?i)^valueA$` '
+            "and fieldB=~`(?i)^valueB$`"
         ]
     )
 
@@ -165,7 +165,7 @@ def test_loki_lf_not_and_expression(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA!~`(?i)valueA` or fieldB!~`(?i)valueB`']
+        == ['{job=~".+"} | logfmt | fieldA!~`(?i)^valueA$` or fieldB!~`(?i)^valueB$`']
     )
 
 
@@ -188,7 +188,7 @@ def test_loki_lf_or_expression(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i)valueA` or fieldB=~`(?i)valueB`']
+        == ['{job=~".+"} | logfmt | fieldA=~`(?i)^valueA$` or fieldB=~`(?i)^valueB$`']
     )
 
 
@@ -212,8 +212,8 @@ def test_loki_lf_not_or_expression(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} !~ `(?i)valueA` | logfmt | fieldA!~`(?i)valueA` and '
-            "fieldB!~`(?i)valueB`"
+            '{job=~".+"} !~ `(?i)valueA` | logfmt | fieldA!~`(?i)^valueA$` and '
+            "fieldB!~`(?i)^valueB$`"
         ]
     )
 
@@ -238,8 +238,8 @@ def test_loki_lf_or_no_filter_expression(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~"eventlog|winlog|windows|fluentbit.*"} | json | aaaa=~`(?i)bbbb` '
-            "or cccc=~`(?i)dddd`"
+            '{job=~"eventlog|winlog|windows|fluentbit.*"} | json | aaaa=~`(?i)^bbbb$` '
+            "or cccc=~`(?i)^dddd$`"
         ]
     )
 
@@ -267,8 +267,8 @@ def test_loki_lf_and_or_expression(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} | logfmt | (fieldA=~`(?i)valueA1` or fieldA=~`(?i)valueA2`) and '
-            "(fieldB=~`(?i)valueB1` or fieldB=~`(?i)valueB2`)"
+            '{job=~".+"} | logfmt | (fieldA=~`(?i)^valueA1$` or fieldA=~`(?i)^valueA2$`) and '
+            "(fieldB=~`(?i)^valueB1$` or fieldB=~`(?i)^valueB2$`)"
         ]
     )
 
@@ -295,8 +295,8 @@ def test_loki_lf_or_and_expression(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} | logfmt | fieldA=~`(?i)valueA1` and fieldB=~`(?i)valueB1` or '
-            "fieldA=~`(?i)valueA2` and fieldB=~`(?i)valueB2`"
+            '{job=~".+"} | logfmt | fieldA=~`(?i)^valueA1$` and fieldB=~`(?i)^valueB1$` or '
+            "fieldA=~`(?i)^valueA2$` and fieldB=~`(?i)^valueB2$`"
         ]
     )
 
@@ -323,8 +323,8 @@ def test_loki_lf_in_expression(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} | logfmt | fieldA=~`(?i)valueA` or fieldA=~`(?i)valueB` '
-            "or fieldA=~`(?i)valueC`"
+            '{job=~".+"} | logfmt | fieldA=~`(?i)^valueA$` or fieldA=~`(?i)^valueB$` '
+            "or fieldA=~`(?i)^valueC$`"
         ]
     )
 
@@ -349,8 +349,8 @@ def test_loki_lf_all_query(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} |~ `(?i)valueA` | logfmt | fieldA=~`(?i)valueA` and '
-            "fieldA=~`(?i)valueB`"
+            '{job=~".+"} |~ `(?i)valueA` | logfmt | fieldA=~`(?i)^valueA$` and '
+            "fieldA=~`(?i)^valueB$`"
         ]
     )
 
@@ -421,7 +421,7 @@ def test_loki_lf_wildcard_single(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} |~ `(?i)va.ue` | logfmt | fieldA=~`(?i)va.ue`']
+        == ['{job=~".+"} |~ `(?i)va.ue` | logfmt | fieldA=~`(?i)^va.ue$`']
     )
 
 
@@ -442,7 +442,7 @@ def test_loki_lf_wildcard_multi(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} |~ `(?i)value.*` | logfmt | fieldA=~`(?i)value.*`']
+        == ['{job=~".+"} |~ `(?i)value.*` | logfmt | fieldA=~`(?i)^value.*`']
     )
 
 
@@ -467,7 +467,7 @@ def test_loki_lf_wildcard_escape(loki_backend: LogQLBackend):
         )
         == [
             '{job=~".+"} |~ `(?i)\\^v\\)\\+\\[al\\]u\\(e.*\\$` | logfmt | '
-            "fieldA=~`(?i)\\^v\\)\\+\\[al\\]u\\(e.*\\$`"
+            "fieldA=~`(?i)^\\^v\\)\\+\\[al\\]u\\(e.*\\$$`"
         ]
     )
 
@@ -491,7 +491,7 @@ def test_loki_lf_regex_query(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} |~ `foo.*bar` | logfmt | fieldA=~`foo.*bar` and fieldB=~`(?i)foo`'
+            '{job=~".+"} |~ `foo.*bar` | logfmt | fieldA=~`foo.*bar` and fieldB=~`(?i)^foo$`'
         ]
     )
 
@@ -555,7 +555,7 @@ def test_loki_lf_field_startswith(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} |~ `(?i)foo.*` | logfmt | fieldA=~`(?i)foo.*`']
+        == ['{job=~".+"} |~ `(?i)foo.*` | logfmt | fieldA=~`(?i)^foo.*`']
     )
 
 
@@ -576,7 +576,7 @@ def test_loki_lf_field_endswith(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} |~ `(?i).*bar` | logfmt | fieldA=~`(?i).*bar`']
+        == ['{job=~".+"} |~ `(?i).*bar` | logfmt | fieldA=~`(?i).*bar$`']
     )
 
 
@@ -664,7 +664,7 @@ def test_loki_lf_base64_query(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} |~ `(?i)dmFsdWU=` | logfmt | fieldA=~`(?i)dmFsdWU=`']
+        == ['{job=~".+"} |~ `(?i)dmFsdWU=` | logfmt | fieldA=~`(?i)^dmFsdWU=$`']
     )
 
 
@@ -686,8 +686,8 @@ def test_loki_lf_base64offset_query(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} | logfmt | fieldA=~`(?i)dmFsdW` or fieldA=~`(?i)ZhbHVl` or '
-            "fieldA=~`(?i)2YWx1Z`"
+            '{job=~".+"} | logfmt | fieldA=~`(?i)^dmFsdW$` or fieldA=~`(?i)^ZhbHVl$` or '
+            "fieldA=~`(?i)^2YWx1Z$`"
         ]
     )
 
@@ -709,7 +709,7 @@ def test_loki_lf_field_name_with_whitespace(loki_backend: LogQLBackend):
           """
             )
         )
-        == ['{job=~".+"} |~ `(?i)value` | logfmt | field_name=~`(?i)value`']
+        == ['{job=~".+"} |~ `(?i)value` | logfmt | field_name=~`(?i)^value$`']
     )
 
 
@@ -730,7 +730,7 @@ def test_loki_lf_field_name_leading_num(loki_backend: LogQLBackend):
           """
             )
         )
-        == ['{job=~".+"} |~ `(?i)value` | logfmt | _0field=~`(?i)value`']
+        == ['{job=~".+"} |~ `(?i)value` | logfmt | _0field=~`(?i)^value$`']
     )
 
 
@@ -751,7 +751,7 @@ def test_loki_lf_field_name_invalid(loki_backend: LogQLBackend):
           """
             )
         )
-        == ['{job=~".+"} |~ `(?i)value` | logfmt | field_name_A_Z=~`(?i)value`']
+        == ['{job=~".+"} |~ `(?i)value` | logfmt | field_name_A_Z=~`(?i)^value$`']
     )
 
 
@@ -775,7 +775,7 @@ def test_loki_lf_unbound(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} |~ `(?i)value` | logfmt | fieldA=~`(?i)valueA`']
+        == ['{job=~".+"} |~ `(?i)value` | logfmt | fieldA=~`(?i)^valueA$`']
     )
 
 
@@ -801,7 +801,7 @@ def test_loki_lf_and_unbound(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} |~ `(?i)valueA` |~ `(?i)valueB` | logfmt | fieldA=~`(?i)valueA`'
+            '{job=~".+"} |~ `(?i)valueA` |~ `(?i)valueB` | logfmt | fieldA=~`(?i)^valueA$`'
         ]
     )
 
@@ -826,7 +826,7 @@ def test_loki_lf_or_unbound(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} |~ `(?i)valueA|valueB` | logfmt | fieldA=~`(?i)valueA`']
+        == ['{job=~".+"} |~ `(?i)valueA|valueB` | logfmt | fieldA=~`(?i)^valueA$`']
     )
 
 
@@ -850,7 +850,7 @@ def test_loki_lf_windows_logsource(loki_backend: LogQLBackend):
         )
         == [
             '{job=~"eventlog|winlog|windows|fluentbit.*"} |~ `(?i)value` | json | '
-            "key1_key2=~`(?i)value`"
+            "key1_key2=~`(?i)^value$`"
         ]
     )
 
@@ -872,7 +872,7 @@ def test_loki_lf_azure_logsource(loki_backend: LogQLBackend):
           """
             )
         )
-        == ['{job="logstash"} |~ `(?i)value` | json | key1_key2=~`(?i)value`']
+        == ['{job="logstash"} |~ `(?i)value` | json | key1_key2=~`(?i)^value$`']
     )
 
 
@@ -904,7 +904,7 @@ def test_loki_lf_very_long_query_or(loki_backend: LogQLBackend):
     assert (
         len(test) > 1
         and all(
-            "|~ `(?i)valueA` |" in q and f"{long_field}=~`(?i)valueA`" in q
+            "|~ `(?i)valueA` |" in q and f"{long_field}=~`(?i)^valueA$`" in q
             for q in test
         )
         and all(len(q) < 5120 for q in test)

--- a/tests/test_backend_loki_case_sensitive.py
+++ b/tests/test_backend_loki_case_sensitive.py
@@ -315,7 +315,7 @@ def test_loki_wildcard_single(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i)va.ue`']
+        == ['{job=~".+"} | logfmt | fieldA=~`(?i)^va.ue$`']
     )
 
 
@@ -336,7 +336,7 @@ def test_loki_wildcard_multi(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i)value.*`']
+        == ['{job=~".+"} | logfmt | fieldA=~`(?i)^value.*`']
     )
 
 
@@ -359,7 +359,7 @@ def test_loki_wildcard_escape(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i)\\^v\\)\\+\\[al\\]u\\(e.*\\$`']
+        == ['{job=~".+"} | logfmt | fieldA=~`(?i)^\\^v\\)\\+\\[al\\]u\\(e.*\\$$`']
     )
 
 
@@ -468,7 +468,7 @@ def test_loki_field_startswith(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i)foo.*`']
+        == ['{job=~".+"} | logfmt | fieldA=~`(?i)^foo.*`']
     )
 
 
@@ -489,7 +489,7 @@ def test_loki_field_endswith(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i).*bar`']
+        == ['{job=~".+"} | logfmt | fieldA=~`(?i).*bar$`']
     )
 
 

--- a/tests/test_backend_loki_field_modifiers.py
+++ b/tests/test_backend_loki_field_modifiers.py
@@ -25,10 +25,10 @@ def loki_backend() -> LogQLBackend:
 
 # Mapping from modifier identifier strings to modifier classes
 modifier_sample_data: Dict[str, Tuple[Any, str]] = {
-    # "modifer": (value, expected_output)
+    # "modifier": (value, expected_output)
     "contains": ("valueA", "fieldA=~`(?i).*valueA.*`"),
-    "startswith": ("valueA", "fieldA=~`(?i)valueA.*`"),
-    "endswith": ("valueA", "fieldA=~`(?i).*valueA`"),
+    "startswith": ("valueA", "fieldA=~`(?i)^valueA.*`"),
+    "endswith": ("valueA", "fieldA=~`(?i).*valueA$`"),
     "exists": ("yes", 'fieldA!=""'),
     "base64": ("valueA", "fieldA=~`(?i)dmFsdWVB`"),
     "base64offset": (

--- a/tests/test_backend_loki_field_modifiers.py
+++ b/tests/test_backend_loki_field_modifiers.py
@@ -30,13 +30,13 @@ modifier_sample_data: Dict[str, Tuple[Any, str]] = {
     "startswith": ("valueA", "fieldA=~`(?i)^valueA.*`"),
     "endswith": ("valueA", "fieldA=~`(?i).*valueA$`"),
     "exists": ("yes", 'fieldA!=""'),
-    "base64": ("valueA", "fieldA=~`(?i)dmFsdWVB`"),
+    "base64": ("valueA", "fieldA=~`(?i)^dmFsdWVB$`"),
     "base64offset": (
         "valueA",
-        "fieldA=~`(?i)dmFsdWVB` or fieldA=~`(?i)ZhbHVlQ` or fieldA=~`(?i)2YWx1ZU`",
+        "fieldA=~`(?i)^dmFsdWVB$` or fieldA=~`(?i)^ZhbHVlQ$` or fieldA=~`(?i)^2YWx1ZU$`",
     ),
-    "wide": ("valueA", "fieldA=~`(?i)v\x00a\x00l\x00u\x00e\x00A\x00`"),
-    "windash": ("-foo", "fieldA=~`(?i)\\-foo` or fieldA=~`(?i)/foo`"),
+    "wide": ("valueA", "fieldA=~`(?i)^v\x00a\x00l\x00u\x00e\x00A\x00$`"),
+    "windash": ("-foo", "fieldA=~`(?i)^\\-foo$` or fieldA=~`(?i)^/foo$`"),
     "re": (".*valueA$", "fieldA=~`.*valueA$`"),
     "i": ("valueA", "valueA"),
     "ignorecase": ("valueA", "valueA"),
@@ -49,7 +49,7 @@ modifier_sample_data: Dict[str, Tuple[Any, str]] = {
     "dotall": ("valueA", "---"),
     "cased": ("valueA", "fieldA=`valueA`"),
     "cidr": ("192.0.0.0/8", 'fieldA=ip("192.0.0.0/8")'),
-    "all": (["valueA", "valueB"], "fieldA=~`(?i)valueA` and fieldA=~`(?i)valueB`"),
+    "all": (["valueA", "valueB"], "fieldA=~`(?i)^valueA$` and fieldA=~`(?i)^valueB$`"),
     "lt": (1, "fieldA<1"),
     "lte": (1, "fieldA<=1"),
     "gt": (1, "fieldA>1"),
@@ -59,7 +59,7 @@ modifier_sample_data: Dict[str, Tuple[Any, str]] = {
         "label_format match_0=`{{ if eq .fieldA .fieldA }}true{{ else }}false{{ end }}`"
         " | match_0=`true`",
     ),
-    "expand": ('"%test%"', "fieldA=~`(?i)valueA`"),
+    "expand": ('"%test%"', "fieldA=~`(?i)^valueA$`"),
 }
 
 

--- a/tests/test_backend_loki_fieldref.py
+++ b/tests/test_backend_loki_fieldref.py
@@ -99,7 +99,9 @@ def test_loki_field_ref_json_multi_selection(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~"eventlog|winlog|windows|fluentbit.*"}  | json | field2=~`(?i)Something`| label_format match_0=`{{ if eq .field1 .fieldA }}true{{ else }}false{{ end }}` | match_0=`true`'
+            '{job=~"eventlog|winlog|windows|fluentbit.*"}  | json | field2=~`(?i)^Something$`'
+            '| label_format match_0=`{{ if eq .field1 .fieldA }}true{{ else }}false{{ end }}` '
+            '| match_0=`true`'
         ]
     )
 

--- a/tests/test_backend_negation_loki.py
+++ b/tests/test_backend_negation_loki.py
@@ -27,7 +27,7 @@ def test_loki_field_not_eq(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA!~`(?i)valueA`']
+        == ['{job=~".+"} | logfmt | fieldA!~`(?i)^valueA$`']
     )
 
 
@@ -69,7 +69,7 @@ def test_loki_field_not_not_eq(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA=~`(?i)valueA`']
+        == ['{job=~".+"} | logfmt | fieldA=~`(?i)^valueA$`']
     )
 
 
@@ -92,7 +92,7 @@ def test_loki_not_and_expression(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA!~`(?i)valueA` or fieldB!~`(?i)valueB`']
+        == ['{job=~".+"} | logfmt | fieldA!~`(?i)^valueA$` or fieldB!~`(?i)^valueB$`']
     )
 
 
@@ -115,7 +115,7 @@ def test_loki_not_or_expression(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA!~`(?i)valueA` and fieldB!~`(?i)valueB`']
+        == ['{job=~".+"} | logfmt | fieldA!~`(?i)^valueA$` and fieldB!~`(?i)^valueB$`']
     )
 
 
@@ -142,8 +142,8 @@ def test_loki_not_and_or_expression(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} | logfmt | fieldA!~`(?i)valueA1` and fieldA!~`(?i)valueA2` '
-            "or fieldB!~`(?i)valueB1` and fieldB!~`(?i)valueB2`"
+            '{job=~".+"} | logfmt | fieldA!~`(?i)^valueA1$` and fieldA!~`(?i)^valueA2$` '
+            "or fieldB!~`(?i)^valueB1$` and fieldB!~`(?i)^valueB2$`"
         ]
     )
 
@@ -170,8 +170,8 @@ def test_loki_not_or_and_expression(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} | logfmt | (fieldA!~`(?i)valueA1` or fieldB!~`(?i)valueB1`) and '
-            "(fieldA!~`(?i)valueA2` or fieldB!~`(?i)valueB2`)"
+            '{job=~".+"} | logfmt | (fieldA!~`(?i)^valueA1$` or fieldB!~`(?i)^valueB1$`) and '
+            "(fieldA!~`(?i)^valueA2$` or fieldB!~`(?i)^valueB2$`)"
         ]
     )
 
@@ -198,8 +198,8 @@ def test_loki_not_in_expression(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} | logfmt | fieldA!~`(?i)valueA` and fieldA!~`(?i)valueB` and '
-            "fieldA!~`(?i)valueC`"
+            '{job=~".+"} | logfmt | fieldA!~`(?i)^valueA$` and fieldA!~`(?i)^valueB$` and '
+            "fieldA!~`(?i)^valueC$`"
         ]
     )
 
@@ -223,7 +223,7 @@ def test_loki_not_all_query(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA!~`(?i)valueA` or fieldA!~`(?i)valueB`']
+        == ['{job=~".+"} | logfmt | fieldA!~`(?i)^valueA$` or fieldA!~`(?i)^valueB$`']
     )
 
 
@@ -251,8 +251,8 @@ def test_loki_not_all_bracket_query(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} | logfmt | (fieldA=~`(?i)valueA` or fieldA=~`(?i)valueB`) and '
-            "(fieldB!~`(?i)valueC` or fieldB!~`(?i)valueD`)"
+            '{job=~".+"} | logfmt | (fieldA=~`(?i)^valueA$` or fieldA=~`(?i)^valueB$`) and '
+            "(fieldB!~`(?i)^valueC$` or fieldB!~`(?i)^valueD$`)"
         ]
     )
 
@@ -274,7 +274,7 @@ def test_loki_not_base64_query(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA!~`(?i)dmFsdWU=`']
+        == ['{job=~".+"} | logfmt | fieldA!~`(?i)^dmFsdWU=$`']
     )
 
 
@@ -296,8 +296,8 @@ def test_loki_not_base64offset_query(loki_backend: LogQLBackend):
             )
         )
         == [
-            '{job=~".+"} | logfmt | fieldA!~`(?i)dmFsdW` and fieldA!~`(?i)ZhbHVl` and '
-            "fieldA!~`(?i)2YWx1Z`"
+            '{job=~".+"} | logfmt | fieldA!~`(?i)^dmFsdW$` and fieldA!~`(?i)^ZhbHVl$` and '
+            "fieldA!~`(?i)^2YWx1Z$`"
         ]
     )
 
@@ -342,7 +342,7 @@ def test_loki_not_wildcard_single(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA!~`(?i)va.ue`']
+        == ['{job=~".+"} | logfmt | fieldA!~`(?i)^va.ue$`']
     )
 
 
@@ -363,7 +363,7 @@ def test_loki_not_wildcard_multi(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA!~`(?i)value.*`']
+        == ['{job=~".+"} | logfmt | fieldA!~`(?i)^value.*`']
     )
 
 
@@ -406,7 +406,7 @@ def test_loki_not_regex_query(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} | logfmt | fieldA!~`foo.*bar` or fieldB!~`(?i)foo`']
+        == ['{job=~".+"} | logfmt | fieldA!~`foo.*bar` or fieldB!~`(?i)^foo$`']
     )
 
 
@@ -558,7 +558,7 @@ def test_loki_not_unbound_or_field(loki_backend: LogQLBackend):
         """
             )
         )
-        == ['{job=~".+"} !~ `(?i)valueA` | logfmt | fieldA!~`(?i)valueB`']
+        == ['{job=~".+"} !~ `(?i)valueA` | logfmt | fieldA!~`(?i)^valueB$`']
     )
 
 
@@ -670,7 +670,7 @@ def test_loki_field_and_not_multi_unbound_expression(loki_backend: LogQLBackend)
             )
         )
         == [
-            '{job=~".+"} !~ `(?i)valueB` !~ `(?i)valueC` | logfmt | fieldA=~`(?i)valueA`'
+            '{job=~".+"} !~ `(?i)valueB` !~ `(?i)valueC` | logfmt | fieldA=~`(?i)^valueA$`'
         ]
     )
 

--- a/tests/test_pipelines_loki.py
+++ b/tests/test_pipelines_loki.py
@@ -38,8 +38,8 @@ def test_loki_grafana_pipeline():
     )
     loki_rule = backend.convert(sigma_rule)
     assert loki_rule == [
-        '{job=~".+"} | logfmt | (path=~`(?i)/a/path/to/something`'
-        " or path=~`(?i)/a/different/path`) and status=200"
+        '{job=~".+"} | logfmt | (path=~`(?i)^/a/path/to/something$`'
+        " or path=~`(?i)^/a/different/path$`) and status=200"
     ]
 
 
@@ -65,7 +65,7 @@ def test_windows_grafana_pipeline():
         '{job=~"eventlog|winlog|windows|fluentbit.*"} | json '
         '| label_format Message=`{{ .message | replace "\\\\" "\\\\\\\\" | replace "\\"" "\\\\\\"" }}` '  # noqa: E501
         '| line_format `{{ regexReplaceAll "([^:]+): ?((?:[^\\\\r]*|$))(\\r\\n|$)" .Message "${1}=\\"${2}\\" "}}` '  # noqa: E501
-        "| logfmt | Image=~`(?i).*\\.exe` and event_id=1"
+        "| logfmt | Image=~`(?i).*\\.exe$` and event_id=1"
     ]
 
 
@@ -91,10 +91,10 @@ def test_okta_json_pipeline():
     )
     loki_rule = backend.convert(sigma_rule)
     assert loki_rule == [
-        '{job=~".+"} | json | (event_eventType=~`(?i)policy\\.lifecycle\\.update` or '
-        "event_eventType=~`(?i)policy\\.lifecycle\\.delete`) and "
-        "event_legacyEventType=~`(?i)core\\.user_auth\\.login_failed` and "
-        "event_displayMessage=~`(?i)Failed\\ login\\ to\\ Okta`"
+        '{job=~".+"} | json | (event_eventType=~`(?i)^policy\\.lifecycle\\.update$` or '
+        "event_eventType=~`(?i)^policy\\.lifecycle\\.delete$`) and "
+        "event_legacyEventType=~`(?i)^core\\.user_auth\\.login_failed$` and "
+        "event_displayMessage=~`(?i)^Failed\\ login\\ to\\ Okta$`"
     ]
 
 
@@ -115,205 +115,207 @@ def test_okta_json_pipeline_exclusive_exhaustive():
     """
 
     rules = [
-        ("eventtype", ['{job=~".+"} | json | event_eventType=~`(?i)test_value`']),
+        ("eventtype", ['{job=~".+"} | json | event_eventType=~`(?i)^test_value$`']),
         (
             "legacyeventtype",
-            ['{job=~".+"} | json | event_legacyEventType=~`(?i)test_value`'],
+            ['{job=~".+"} | json | event_legacyEventType=~`(?i)^test_value$`'],
         ),
         (
             "actor.alternateid",
-            ['{job=~".+"} | json | event_actor_alternateId=~`(?i)test_value`'],
+            ['{job=~".+"} | json | event_actor_alternateId=~`(?i)^test_value$`'],
         ),
         (
             "actor.displayname",
-            ['{job=~".+"} | json | event_actor_displayName=~`(?i)test_value`'],
+            ['{job=~".+"} | json | event_actor_displayName=~`(?i)^test_value$`'],
         ),
         (
             "client.useragent.rawuseragent",
             [
-                '{job=~".+"} | json | event_client_userAgent_rawUserAgent=~`(?i)test_value`'
+                '{job=~".+"} | json | event_client_userAgent_rawUserAgent=~`(?i)^test_value$`'
             ],
         ),
         (
             "client.useragent.os",
-            ['{job=~".+"} | json | event_client_userAgent_os=~`(?i)test_value`'],
+            ['{job=~".+"} | json | event_client_userAgent_os=~`(?i)^test_value$`'],
         ),
         (
             "client.useragent.browser",
-            ['{job=~".+"} | json | event_client_userAgent_browser=~`(?i)test_value`'],
+            ['{job=~".+"} | json | event_client_userAgent_browser=~`(?i)^test_value$`'],
         ),
         (
             "client.geographicalcontext.geolocation.lat",
             [
-                '{job=~".+"} | json | event_client_geographicalContext_geolocation_lat=~`(?i)test_v'
-                "alue`"
+                '{job=~".+"} | json | event_client_geographicalContext_geolocation_lat=~`(?i)^test_'
+                "value$`"
             ],
         ),
         (
             "client.geographicalcontext.geolocation.lon",
             [
-                '{job=~".+"} | json | event_client_geographicalContext_geolocation_lon=~`(?i)test_v'
-                "alue`"
+                '{job=~".+"} | json | event_client_geographicalContext_geolocation_lon=~`(?i)^test_'
+                "value$`"
             ],
         ),
         (
             "client.geographicalcontext.city",
             [
-                '{job=~".+"} | json | event_client_geographicalContext_city=~`(?i)test_value`'
+                '{job=~".+"} | json | event_client_geographicalContext_city=~`(?i)^test_value$`'
             ],
         ),
         (
             "client.geographicalcontext.state",
             [
-                '{job=~".+"} | json | event_client_geographicalContext_state=~`(?i)test_value`'
+                '{job=~".+"} | json | event_client_geographicalContext_state=~`(?i)^test_value$`'
             ],
         ),
         (
             "client.geographicalcontext.country",
             [
-                '{job=~".+"} | json | event_client_geographicalContext_country=~`(?i)test_value`'
+                '{job=~".+"} | json | event_client_geographicalContext_country=~`(?i)^test_value$`'
             ],
         ),
         (
             "client.geographicalcontext.postalcode",
             [
-                '{job=~".+"} | json | event_client_geographicalContext_postalCode=~`(?i)test_value`'
+                '{job=~".+"} | json | event_client_geographicalContext_postalCode=~`(?i)^test_'
+                'value$`'
             ],
         ),
         (
             "client.ipaddress",
-            ['{job=~".+"} | json | event_client_ipAddress=~`(?i)test_value`'],
+            ['{job=~".+"} | json | event_client_ipAddress=~`(?i)^test_value$`'],
         ),
         (
             "debugcontext.debugdata.requesturi",
             [
-                '{job=~".+"} | json | event_debugContext_debugData_requestUri=~`(?i)test_value`'
+                '{job=~".+"} | json | event_debugContext_debugData_requestUri=~`(?i)^test_value$`'
             ],
         ),
         (
             "debugcontext.debugdata.originalprincipal.id",
             [
-                '{job=~".+"} | json | event_debugContext_debugData_originalPrincipal_id=~`(?i)test_'
-                "value`"
+                '{job=~".+"} | json | event_debugContext_debugData_originalPrincipal_id=~`(?i)^test'
+                "_value$`"
             ],
         ),
         (
             "debugcontext.debugdata.originalprincipal.type",
             [
-                '{job=~".+"} | json | event_debugContext_debugData_originalPrincipal_type=~`(?i)tes'
-                "t_value`"
+                '{job=~".+"} | json | event_debugContext_debugData_originalPrincipal_type=~`(?i)'
+                "^test_value$`"
             ],
         ),
         (
             "debugcontext.debugdata.originalprincipal.alternateid",
             [
                 '{job=~".+"} | json | event_debugContext_debugData_originalPrincipal_alternateId=~`'
-                "(?i)test_value`"
+                "(?i)^test_value$`"
             ],
         ),
         (
             "debugcontext.debugdata.originalprincipal.displayname",
             [
                 '{job=~".+"} | json | event_debugContext_debugData_originalPrincipal_displayName=~`'
-                "(?i)test_value`"
+                "(?i)^test_value$`"
             ],
         ),
         (
             "debugcontext.debugdata.behaviors",
             [
-                '{job=~".+"} | json | event_debugContext_debugData_behaviors=~`(?i)test_value`'
+                '{job=~".+"} | json | event_debugContext_debugData_behaviors=~`(?i)^test_value$`'
             ],
         ),
         (
             "debugcontext.debugdata.logonlysecuritydata",
             [
-                '{job=~".+"} | json | event_debugContext_debugData_logOnlySecurityData=~`(?i)test_v'
-                "alue`"
+                '{job=~".+"} | json | event_debugContext_debugData_logOnlySecurityData=~`(?i)^test_'
+                "value$`"
             ],
         ),
         (
             "authenticationcontext.authenticationprovider",
             [
-                '{job=~".+"} | json | event_authenticationContext_authenticationProvider=~`(?i)test'
-                "_value`"
+                '{job=~".+"} | json | event_authenticationContext_authenticationProvider=~`(?i)'
+                "^test_value$`"
             ],
         ),
         (
             "authenticationcontext.authenticationstep",
             [
-                '{job=~".+"} | json | event_authenticationContext_authenticationStep=~`(?i)test_val'
-                "ue`"
+                '{job=~".+"} | json | event_authenticationContext_authenticationStep=~`(?i)^test_'
+                'value$`'
             ],
         ),
         (
             "authenticationcontext.credentialprovider",
             [
-                '{job=~".+"} | json | event_authenticationContext_credentialProvider=~`(?i)test_val'
-                "ue`"
+                '{job=~".+"} | json | event_authenticationContext_credentialProvider=~`(?i)^test_'
+                'value$`'
             ],
         ),
         (
             "authenticationcontext.credentialtype",
             [
-                '{job=~".+"} | json | event_authenticationContext_credentialType=~`(?i)test_value`'
+                '{job=~".+"} | json | event_authenticationContext_credentialType=~`(?i)^test_'
+                'value$`'
             ],
         ),
         (
             "authenticationcontext.issuer.id",
             [
-                '{job=~".+"} | json | event_authenticationContext_issuer_id=~`(?i)test_value`'
+                '{job=~".+"} | json | event_authenticationContext_issuer_id=~`(?i)^test_value$`'
             ],
         ),
         (
             "authenticationcontext.issuer.type",
             [
-                '{job=~".+"} | json | event_authenticationContext_issuer_type=~`(?i)test_value`'
+                '{job=~".+"} | json | event_authenticationContext_issuer_type=~`(?i)^test_value$`'
             ],
         ),
         (
             "authenticationcontext.externalsessionid",
             [
-                '{job=~".+"} | json | event_authenticationContext_externalSessionId=~`(?i)test_valu'
-                "e`"
+                '{job=~".+"} | json | event_authenticationContext_externalSessionId=~`(?i)^test_'
+                'value$`'
             ],
         ),
         (
             "authenticationcontext.interface",
             [
-                '{job=~".+"} | json | event_authenticationContext_interface=~`(?i)test_value`'
+                '{job=~".+"} | json | event_authenticationContext_interface=~`(?i)^test_value$`'
             ],
         ),
         (
             "securitycontext.asnumber",
-            ['{job=~".+"} | json | event_securityContext_asNumber=~`(?i)test_value`'],
+            ['{job=~".+"} | json | event_securityContext_asNumber=~`(?i)^test_value$`'],
         ),
         (
             "securitycontext.asorg",
-            ['{job=~".+"} | json | event_securityContext_asOrg=~`(?i)test_value`'],
+            ['{job=~".+"} | json | event_securityContext_asOrg=~`(?i)^test_value$`'],
         ),
         (
             "securitycontext.isp",
-            ['{job=~".+"} | json | event_securityContext_isp=~`(?i)test_value`'],
+            ['{job=~".+"} | json | event_securityContext_isp=~`(?i)^test_value$`'],
         ),
         (
             "securitycontext.domain",
-            ['{job=~".+"} | json | event_securityContext_domain=~`(?i)test_value`'],
+            ['{job=~".+"} | json | event_securityContext_domain=~`(?i)^test_value$`'],
         ),
         (
             "securitycontext.isproxy",
-            ['{job=~".+"} | json | event_securityContext_isProxy=~`(?i)test_value`'],
+            ['{job=~".+"} | json | event_securityContext_isProxy=~`(?i)^test_value$`'],
         ),
         (
             "target.alternateid",
-            ['{job=~".+"} | json | event_target_alternateId=~`(?i)test_value`'],
+            ['{job=~".+"} | json | event_target_alternateId=~`(?i)^test_value$`'],
         ),
         (
             "target.displayname",
-            ['{job=~".+"} | json | event_target_displayName=~`(?i)test_value`'],
+            ['{job=~".+"} | json | event_target_displayName=~`(?i)^test_value$`'],
         ),
         (
             "target.detailentry",
-            ['{job=~".+"} | json | event_target_detailEntry=~`(?i)test_value`'],
+            ['{job=~".+"} | json | event_target_detailEntry=~`(?i)^test_value$`'],
         ),
     ]
 
@@ -352,7 +354,7 @@ def test_loki_parser_pipeline():
         """
     )
     loki_rule = backend.convert(sigma_rule)
-    assert loki_rule == ['{job=~".+"} | pattern `<ip> <ts> <msg>` | msg=~`(?i)testing`']
+    assert loki_rule == ['{job=~".+"} | pattern `<ip> <ts> <msg>` | msg=~`(?i)^testing$`']
 
 
 def test_loki_logsource_selection_pipeline():
@@ -385,7 +387,7 @@ def test_loki_logsource_selection_pipeline():
     )
     loki_rule = backend.convert(sigma_rule)
     assert loki_rule == [
-        "{job=`mylogs`,filename=~`.*[\\d]+.log$`} | logfmt | msg=~`(?i)testing`"
+        "{job=`mylogs`,filename=~`.*[\\d]+.log$`} | logfmt | msg=~`(?i)^testing$`"
     ]
 
 


### PR DESCRIPTION
Automatically introduce start (^) and/or end ($) anchors into all generated label filter regular expressions that do not (respectively) start and/or end with explicit unbound-length wildcards.

This uses a relatively complex regex to identify where anchors are present when extracting line filters. Some simple testing can [be seen here](https://regex101.com/r/H8YQt1/2) - feel free to add further examples to explore other potential edge cases. I also had to update a wide range of unit tests to reflect the new behavior.

Note that I have also raised a query with the Loki team via our internal Slack (see the #loki channel) to ensure that the identified behavior is not a bug on their side.

Fixes #163 