### PR TITLE
Custom log source pipeline

### DIFF
--- a/sigma/pipelines/loki/__init__.py
+++ b/sigma/pipelines/loki/__init__.py
@@ -1,6 +1,7 @@
 from .loki import (
     LokiCustomAttributes,
     SetCustomAttributeTransformation,
+    CustomLogSourceTransformation,
     loki_grafana_logfmt,
     loki_promtail_sysmon,
     loki_okta_system_log,
@@ -9,6 +10,7 @@ from .loki import (
 __all__ = (
     "LokiCustomAttributes",
     "SetCustomAttributeTransformation",
+    "CustomLogSourceTransformation",
     "loki_grafana_logfmt",
     "loki_promtail_sysmon",
     "loki_okta_system_log",

--- a/sigma/pipelines/loki/loki.py
+++ b/sigma/pipelines/loki/loki.py
@@ -83,7 +83,7 @@ class CustomLogSourceTransformation(Transformation):
                             "can only refer to a single field"
                         )
                     else:
-                        refs[field.removesuffix("|fieldref")] = value
+                        refs[field[:-len("|fieldref")]] = value
                 else:
                     selectors.append(format_log_source_selector(field, value))
             if len(refs) > 0:
@@ -96,7 +96,7 @@ class CustomLogSourceTransformation(Transformation):
                 ]
                 if len(field_values) > 0:
                     for label, field_name in refs.items():
-                        values: list[Union[str, int, None]] = []
+                        values: List[Union[str, int, None]] = []
                         for mapping in field_values:
                             if (
                                 field_name in mapping

--- a/sigma/pipelines/loki/loki.py
+++ b/sigma/pipelines/loki/loki.py
@@ -171,11 +171,11 @@ class CustomLogSourceTransformation(Transformation):
                             values.append(item.value)
                     if len(values) == 0 or skip:
                         continue
-                    if len(values) == 1:
+                    if len(values) == 1 and isinstance(values[0], SigmaString):
                         if negated:
                             op = "!="
                         value = values[0]
-                    if len(values) > 1:
+                    else:
                         op = "=~"
                         if negated:
                             op = "!~"

--- a/sigma/pipelines/loki/loki.py
+++ b/sigma/pipelines/loki/loki.py
@@ -89,7 +89,7 @@ class CustomLogSourceTransformation(Transformation):
                     detection.to_plain()
                     for detection in rule.detection.detections.values()
                 ]
-                field_values: list[dict[str, str | int | None]] = [
+                field_values: list[dict[str, Union[str, int, None]]] = [
                     d for d in plain if isinstance(d, dict)
                 ]
                 if len(field_values) > 0:

--- a/sigma/shared.py
+++ b/sigma/shared.py
@@ -1,0 +1,79 @@
+import re
+from typing import List, Union
+from sigma.types import SigmaCasedString, SigmaString, SigmaRegularExpression
+
+
+def sanitize_label_key(key: str, isprefix: bool = True) -> str:
+    """Implements the logic used by Loki to sanitize labels.
+
+    See: https://github.com/grafana/loki/blob/main/pkg/logql/log/util.go#L21"""
+    # pySigma treats null or empty fields as unbound expressions, rather than keys
+    if key is None or len(key) == 0:  # pragma: no cover
+        return ""
+    key = key.strip()
+    if len(key) == 0:
+        return key
+    if isprefix and key[0] >= "0" and key[0] <= "9":
+        key = "_" + key
+    return "".join(
+        (
+            (
+                r
+                if (r >= "a" and r <= "z")
+                or (r >= "A" and r <= "Z")
+                or r == "_"
+                or (r >= "0" and r <= "9")
+                else "_"
+            )
+            for r in key
+        )
+    )
+
+
+def quote_string_value(s: SigmaString) -> str:
+    """By default, use the tilde character to quote fields, which needs limited escaping.
+    If the value contains a tilde character, use double quotes and apply more rigourous
+    escaping."""
+    quote = "`"
+    if any([c == quote for c in str(s)]):
+        quote = '"'
+    # If our string doesn't contain any tilde characters
+    if quote == "`":
+        converted = s.convert()
+    else:
+        converted = s.convert(escape_char="\\", add_escaped='"\\')
+    return quote + converted + quote
+
+
+def join_or_values_re(
+    exprs: List[Union[SigmaString, SigmaRegularExpression]], case_insensitive: bool
+) -> str:
+    # This makes the regex case insensitive if any values are SigmaStrings
+    # or if any of the regexes are case insensitive
+    # TODO: can we make this more precise?
+    case_insensitive = any(
+        (
+            isinstance(val, SigmaString)
+            and case_insensitive
+            and not isinstance(val, SigmaCasedString)
+        )
+        or (isinstance(val, SigmaRegularExpression) and val.regexp.startswith("(?i)"))
+        for val in exprs
+    )
+    or_value = "|".join(
+        (
+            (
+                re.escape(str(val))
+                if isinstance(val, SigmaString)
+                else re.sub("^\\(\\?i\\)", "", val.regexp)
+            )
+            for val in exprs
+        )
+    )
+    if case_insensitive:
+        or_value = "(?i)" + or_value
+    if "`" in or_value:
+        or_value = '"' + SigmaRegularExpression(or_value).escape(('"',)) + '"'
+    else:
+        or_value = "`" + or_value + "`"
+    return or_value

--- a/tests/test_backend_loki_fieldref.py
+++ b/tests/test_backend_loki_fieldref.py
@@ -100,8 +100,8 @@ def test_loki_field_ref_json_multi_selection(loki_backend: LogQLBackend):
         )
         == [
             '{job=~"eventlog|winlog|windows|fluentbit.*"}  | json | field2=~`(?i)^Something$`'
-            '| label_format match_0=`{{ if eq .field1 .fieldA }}true{{ else }}false{{ end }}` '
-            '| match_0=`true`'
+            "| label_format match_0=`{{ if eq .field1 .fieldA }}true{{ else }}false{{ end }}` "
+            "| match_0=`true`"
         ]
     )
 

--- a/tests/test_pipelines_loki.py
+++ b/tests/test_pipelines_loki.py
@@ -395,7 +395,12 @@ def test_simple_custom_log_source_pipeline(sigma_rules: SigmaCollection):
             ProcessingItem(
                 identifier="complex_custom_log_source",
                 transformation=CustomLogSourceTransformation(
-                    selection={"job": ["a", "b", "c"], "message|fieldref": "msg"}
+                    selection={
+                        "job": ["a", "b", "c"],
+                        "message|fieldref": "msg",
+                        "env": "$product",
+                    },
+                    template=True,
                 ),
             )
         ],
@@ -403,7 +408,7 @@ def test_simple_custom_log_source_pipeline(sigma_rules: SigmaCollection):
     backend = LogQLBackend(processing_pipeline=pipeline)
     loki_rule = backend.convert(sigma_rules)
     assert loki_rule == [
-        "{job=~`a|b|c`,message=`testing`} | logfmt | msg=~`(?i)^testing$`"
+        "{job=~`a|b|c`,env=`test`,message=`testing`} | logfmt | msg=~`(?i)^testing$`"
     ]
 
 


### PR DESCRIPTION
Introduce a new pipeline to enable the creation of log sources for rules as a YAML pipeline, utilising the fields specified in the rule where relevant to dynamically build matching values.

A valid example of this pipeline might be:
```yaml
name: Example custom log source
priority: 20
transformations:
    - id: custom_log_source
      type: set_custom_log_source
      selection:
          name|re: `okta.*`
          namespace|contains: `loki`
          eventType|fieldref: eventtype
          stream:
              - stderr
              - stdout
```

If applied to the following rule:
```yaml
title: Test
status: test
logsource:
    product: okta
    service: okta
detection:
    sel:
        eventtype: system.push.send_factor_verify_push
    condition: sel
```

It would generate the following log source for the conversion:
```
{name=~`okta.*`,namespace=~`.*loki.*`,eventType=`system.push.send_factor_verify_push`,stream=~`stderr|stdout`}
```