### PR TITLE
Enable simple event count correlation rules

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -209,13 +209,13 @@ toml = ["tomli"]
 
 [[package]]
 name = "exceptiongroup"
-version = "1.2.1"
+version = "1.2.2"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.2.1-py3-none-any.whl", hash = "sha256:5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad"},
-    {file = "exceptiongroup-1.2.1.tar.gz", hash = "sha256:a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16"},
+    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
+    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
 ]
 
 [package.extras]
@@ -347,44 +347,44 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "1.10.1"
+version = "1.11.1"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mypy-1.10.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e36f229acfe250dc660790840916eb49726c928e8ce10fbdf90715090fe4ae02"},
-    {file = "mypy-1.10.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:51a46974340baaa4145363b9e051812a2446cf583dfaeba124af966fa44593f7"},
-    {file = "mypy-1.10.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:901c89c2d67bba57aaaca91ccdb659aa3a312de67f23b9dfb059727cce2e2e0a"},
-    {file = "mypy-1.10.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0cd62192a4a32b77ceb31272d9e74d23cd88c8060c34d1d3622db3267679a5d9"},
-    {file = "mypy-1.10.1-cp310-cp310-win_amd64.whl", hash = "sha256:a2cbc68cb9e943ac0814c13e2452d2046c2f2b23ff0278e26599224cf164e78d"},
-    {file = "mypy-1.10.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bd6f629b67bb43dc0d9211ee98b96d8dabc97b1ad38b9b25f5e4c4d7569a0c6a"},
-    {file = "mypy-1.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a1bbb3a6f5ff319d2b9d40b4080d46cd639abe3516d5a62c070cf0114a457d84"},
-    {file = "mypy-1.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8edd4e9bbbc9d7b79502eb9592cab808585516ae1bcc1446eb9122656c6066f"},
-    {file = "mypy-1.10.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6166a88b15f1759f94a46fa474c7b1b05d134b1b61fca627dd7335454cc9aa6b"},
-    {file = "mypy-1.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:5bb9cd11c01c8606a9d0b83ffa91d0b236a0e91bc4126d9ba9ce62906ada868e"},
-    {file = "mypy-1.10.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d8681909f7b44d0b7b86e653ca152d6dff0eb5eb41694e163c6092124f8246d7"},
-    {file = "mypy-1.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:378c03f53f10bbdd55ca94e46ec3ba255279706a6aacaecac52ad248f98205d3"},
-    {file = "mypy-1.10.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bacf8f3a3d7d849f40ca6caea5c055122efe70e81480c8328ad29c55c69e93e"},
-    {file = "mypy-1.10.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:701b5f71413f1e9855566a34d6e9d12624e9e0a8818a5704d74d6b0402e66c04"},
-    {file = "mypy-1.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c4c2992f6ea46ff7fce0072642cfb62af7a2484efe69017ed8b095f7b39ef31"},
-    {file = "mypy-1.10.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:604282c886497645ffb87b8f35a57ec773a4a2721161e709a4422c1636ddde5c"},
-    {file = "mypy-1.10.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:37fd87cab83f09842653f08de066ee68f1182b9b5282e4634cdb4b407266bade"},
-    {file = "mypy-1.10.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8addf6313777dbb92e9564c5d32ec122bf2c6c39d683ea64de6a1fd98b90fe37"},
-    {file = "mypy-1.10.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5cc3ca0a244eb9a5249c7c583ad9a7e881aa5d7b73c35652296ddcdb33b2b9c7"},
-    {file = "mypy-1.10.1-cp38-cp38-win_amd64.whl", hash = "sha256:1b3a2ffce52cc4dbaeee4df762f20a2905aa171ef157b82192f2e2f368eec05d"},
-    {file = "mypy-1.10.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fe85ed6836165d52ae8b88f99527d3d1b2362e0cb90b005409b8bed90e9059b3"},
-    {file = "mypy-1.10.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c2ae450d60d7d020d67ab440c6e3fae375809988119817214440033f26ddf7bf"},
-    {file = "mypy-1.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6be84c06e6abd72f960ba9a71561c14137a583093ffcf9bbfaf5e613d63fa531"},
-    {file = "mypy-1.10.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2189ff1e39db399f08205e22a797383613ce1cb0cb3b13d8bcf0170e45b96cc3"},
-    {file = "mypy-1.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:97a131ee36ac37ce9581f4220311247ab6cba896b4395b9c87af0675a13a755f"},
-    {file = "mypy-1.10.1-py3-none-any.whl", hash = "sha256:71d8ac0b906354ebda8ef1673e5fde785936ac1f29ff6987c7483cfbd5a4235a"},
-    {file = "mypy-1.10.1.tar.gz", hash = "sha256:1f8f492d7db9e3593ef42d4f115f04e556130f2819ad33ab84551403e97dd4c0"},
+    {file = "mypy-1.11.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a32fc80b63de4b5b3e65f4be82b4cfa362a46702672aa6a0f443b4689af7008c"},
+    {file = "mypy-1.11.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c1952f5ea8a5a959b05ed5f16452fddadbaae48b5d39235ab4c3fc444d5fd411"},
+    {file = "mypy-1.11.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e1e30dc3bfa4e157e53c1d17a0dad20f89dc433393e7702b813c10e200843b03"},
+    {file = "mypy-1.11.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2c63350af88f43a66d3dfeeeb8d77af34a4f07d760b9eb3a8697f0386c7590b4"},
+    {file = "mypy-1.11.1-cp310-cp310-win_amd64.whl", hash = "sha256:a831671bad47186603872a3abc19634f3011d7f83b083762c942442d51c58d58"},
+    {file = "mypy-1.11.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7b6343d338390bb946d449677726edf60102a1c96079b4f002dedff375953fc5"},
+    {file = "mypy-1.11.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e4fe9f4e5e521b458d8feb52547f4bade7ef8c93238dfb5bbc790d9ff2d770ca"},
+    {file = "mypy-1.11.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:886c9dbecc87b9516eff294541bf7f3655722bf22bb898ee06985cd7269898de"},
+    {file = "mypy-1.11.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fca4a60e1dd9fd0193ae0067eaeeb962f2d79e0d9f0f66223a0682f26ffcc809"},
+    {file = "mypy-1.11.1-cp311-cp311-win_amd64.whl", hash = "sha256:0bd53faf56de9643336aeea1c925012837432b5faf1701ccca7fde70166ccf72"},
+    {file = "mypy-1.11.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f39918a50f74dc5969807dcfaecafa804fa7f90c9d60506835036cc1bc891dc8"},
+    {file = "mypy-1.11.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0bc71d1fb27a428139dd78621953effe0d208aed9857cb08d002280b0422003a"},
+    {file = "mypy-1.11.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b868d3bcff720dd7217c383474008ddabaf048fad8d78ed948bb4b624870a417"},
+    {file = "mypy-1.11.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a707ec1527ffcdd1c784d0924bf5cb15cd7f22683b919668a04d2b9c34549d2e"},
+    {file = "mypy-1.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:64f4a90e3ea07f590c5bcf9029035cf0efeae5ba8be511a8caada1a4893f5525"},
+    {file = "mypy-1.11.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:749fd3213916f1751fff995fccf20c6195cae941dc968f3aaadf9bb4e430e5a2"},
+    {file = "mypy-1.11.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b639dce63a0b19085213ec5fdd8cffd1d81988f47a2dec7100e93564f3e8fb3b"},
+    {file = "mypy-1.11.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c956b49c5d865394d62941b109728c5c596a415e9c5b2be663dd26a1ff07bc0"},
+    {file = "mypy-1.11.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:45df906e8b6804ef4b666af29a87ad9f5921aad091c79cc38e12198e220beabd"},
+    {file = "mypy-1.11.1-cp38-cp38-win_amd64.whl", hash = "sha256:d44be7551689d9d47b7abc27c71257adfdb53f03880841a5db15ddb22dc63edb"},
+    {file = "mypy-1.11.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2684d3f693073ab89d76da8e3921883019ea8a3ec20fa5d8ecca6a2db4c54bbe"},
+    {file = "mypy-1.11.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:79c07eb282cb457473add5052b63925e5cc97dfab9812ee65a7c7ab5e3cb551c"},
+    {file = "mypy-1.11.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11965c2f571ded6239977b14deebd3f4c3abd9a92398712d6da3a772974fad69"},
+    {file = "mypy-1.11.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a2b43895a0f8154df6519706d9bca8280cda52d3d9d1514b2d9c3e26792a0b74"},
+    {file = "mypy-1.11.1-cp39-cp39-win_amd64.whl", hash = "sha256:1a81cf05975fd61aec5ae16501a091cfb9f605dc3e3c878c0da32f250b74760b"},
+    {file = "mypy-1.11.1-py3-none-any.whl", hash = "sha256:0624bdb940255d2dd24e829d99a13cfeb72e4e9031f9492148f410ed30bcab54"},
+    {file = "mypy-1.11.1.tar.gz", hash = "sha256:f404a0b069709f18bbdb702eb3dcfe51910602995de00bd39cea3050b5772d08"},
 ]
 
 [package.dependencies]
 mypy-extensions = ">=1.0.0"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = ">=4.1.0"
+typing-extensions = ">=4.6.0"
 
 [package.extras]
 dmypy = ["psutil (>=4.0)"]
@@ -405,13 +405,13 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "23.2"
+version = "24.1"
 description = "Core utilities for Python packages"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
-    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
+    {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
+    {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
 ]
 
 [[package]]
@@ -445,18 +445,18 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pysigma"
-version = "0.11.8"
+version = "0.11.9"
 description = "Sigma rule processing and conversion tools"
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "pysigma-0.11.8-py3-none-any.whl", hash = "sha256:b8a811c36ea97a66ceaff158de92b054b5531d1a2fe3c4317133101c624ad97e"},
-    {file = "pysigma-0.11.8.tar.gz", hash = "sha256:08ae6d134567960c39a1907c9111504a1a4cdbabe71555c1f62f7d67a6228298"},
+    {file = "pysigma-0.11.9-py3-none-any.whl", hash = "sha256:1674ce2df2cc5c27b15b03c6e0915500f1b15a78b6e758c405b1cfa994ac827f"},
+    {file = "pysigma-0.11.9.tar.gz", hash = "sha256:6606b05b7914510cc7dd7f4db788dc505332826ebe59a769c03d2e759b8fcd2d"},
 ]
 
 [package.dependencies]
 jinja2 = ">=3.1,<4.0"
-packaging = ">=22.0,<24.0"
+packaging = ">=24.1,<25.0"
 pyparsing = ">=3.1,<4.0"
 pyyaml = ">=6.0,<7.0"
 requests = ">=2.31,<3.0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -684,4 +684,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "7136d42c60ea93a18939b890f296d61895da65d6b9016a51f32b38cfd8f8a801"
+content-hash = "7d98f33448906b5fd5172ba8a3ac66b9ca75b80817024768af4fe1528507e23c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,11 @@ packages = [{ include = "sigma" }]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pysigma = "^0.11.6"
+pysigma = "^0.11.9"
 
 [tool.poetry.group.dev.dependencies]
 coverage = "^7.6.0"
-mypy = "^1.10.0"
+mypy = "^1.11.0"
 pytest = "^7.4.4"
 pytest-cov = "^4.1.0"
 pytest-mypy = "^0.10.3"

--- a/sigma/backends/loki/loki.py
+++ b/sigma/backends/loki/loki.py
@@ -325,15 +325,13 @@ class LogQLBackend(TextQueryBackend):
         "default": "{aggregate} {condition}",
     }
     correlation_search_single_rule_expression = "{query}"
-    correlation_search_field_normalization_expression = "{field}"
-    correlation_search_field_normalization_expression_joiner = ","
     event_count_aggregation_expression = {
-        "default": "sum by {groupby} (count_over_time({query} [{timespan}]))",
+        "default": "sum{groupby}(count_over_time({query} [{timespan}]))",
     }
     # Loki supports all the default time span specifiers (s, m, h, d) defined for correlation rules
     timespan_mapping = {}
     groupby_expression = {
-        "default": "({fields})",
+        "default": " by ({fields}) ",
     }
     groupby_field_expression = {
         "default": "{field}",

--- a/sigma/backends/loki/loki.py
+++ b/sigma/backends/loki/loki.py
@@ -1088,8 +1088,7 @@ class LogQLBackend(TextQueryBackend):
             groupby=self.convert_correlation_aggregation_groupby_from_template(
                 rule.group_by, method
             ),
-            # FIXME: this only supports a single rule that produces a single query
-            query=rule.rules[0].rule.get_conversion_result()[0]
+            query=self.convert_correlation_search(rule)
         )
 
     # Swapping the meaning of "deferred" expressions so they appear at the start of a query,

--- a/tests/test_backend_loki_event_count_correlation.py
+++ b/tests/test_backend_loki_event_count_correlation.py
@@ -8,8 +8,38 @@ def loki_backend():
     return LogQLBackend()
 
 
+def test_loki_default_event_count_no_field(loki_backend: LogQLBackend):
+    rules = SigmaCollection.from_yaml(
+        """
+title: Test Rule
+name: test_rule
+status: test
+logsource:
+    category: test_category
+    product: test_product
+detection:
+    sel:
+        fieldA: valueA
+    condition: sel
+---
+title: Test Correlation
+status: test
+correlation:
+    type: event_count
+    rules:
+        - test_rule
+    timespan: 30s
+    condition:
+        eq: 42
+"""
+    )
+    queries = loki_backend.convert(rules)
+    assert queries == ['sum(count_over_time({job=~".+"} | logfmt | '
+                       'fieldA=~`(?i)^valueA$` [30s])) == 42']
+
+
 # Testing event count correlation rules
-def test_loki_default_event_count_simple(loki_backend: LogQLBackend):
+def test_loki_default_event_count_single_field(loki_backend: LogQLBackend):
     rules = SigmaCollection.from_yaml(
         """
 title: Test Rule
@@ -39,3 +69,37 @@ correlation:
     queries = loki_backend.convert(rules)
     assert queries == ['sum by (fieldB) (count_over_time({job=~".+"} | logfmt | '
                        'fieldA=~`(?i)^valueA$` [5m])) >= 1']
+
+
+# Testing event count correlation rules
+def test_loki_default_event_count_multiple_fields(loki_backend: LogQLBackend):
+    rules = SigmaCollection.from_yaml(
+        """
+title: Test Rule
+name: test_rule
+status: test
+logsource:
+    category: test_category
+    product: test_product
+detection:
+    sel:
+        fieldA: valueA
+    condition: sel
+---
+title: Test Correlation
+status: test
+correlation:
+    type: event_count
+    rules:
+        - test_rule
+    group-by:
+        - fieldB
+        - fieldC
+    timespan: 1d
+    condition:
+        lt: 100
+"""
+    )
+    queries = loki_backend.convert(rules)
+    assert queries == ['sum by (fieldB, fieldC) (count_over_time({job=~".+"} | logfmt | '
+                       'fieldA=~`(?i)^valueA$` [1d])) < 100']

--- a/tests/test_backend_loki_event_count_correlation.py
+++ b/tests/test_backend_loki_event_count_correlation.py
@@ -1,0 +1,41 @@
+import pytest
+from sigma.backends.loki import LogQLBackend
+from sigma.collection import SigmaCollection
+
+
+@pytest.fixture
+def loki_backend():
+    return LogQLBackend()
+
+
+# Testing event count correlation rules
+def test_loki_default_event_count_simple(loki_backend: LogQLBackend):
+    rules = SigmaCollection.from_yaml(
+        """
+title: Test Rule
+name: test_rule
+status: test
+logsource:
+    category: test_category
+    product: test_product
+detection:
+    sel:
+        fieldA: valueA
+    condition: sel
+---
+title: Test Correlation
+status: test
+correlation:
+    type: event_count
+    rules:
+        - test_rule
+    group-by:
+        - fieldB
+    timespan: 5m
+    condition:
+        gte: 1
+"""
+    )
+    queries = loki_backend.convert(rules)
+    assert queries == ['sum by (fieldB) (count_over_time({job=~".+"} | logfmt | '
+                       'fieldA=~`(?i)^valueA$` [5m])) >= 1']

--- a/tests/test_backend_loki_event_count_correlation.py
+++ b/tests/test_backend_loki_event_count_correlation.py
@@ -38,7 +38,6 @@ correlation:
                        'fieldA=~`(?i)^valueA$` [30s])) == 42']
 
 
-# Testing event count correlation rules
 def test_loki_default_event_count_single_field(loki_backend: LogQLBackend):
     rules = SigmaCollection.from_yaml(
         """
@@ -71,7 +70,6 @@ correlation:
                        'fieldA=~`(?i)^valueA$` [5m])) >= 1']
 
 
-# Testing event count correlation rules
 def test_loki_default_event_count_multiple_fields(loki_backend: LogQLBackend):
     rules = SigmaCollection.from_yaml(
         """


### PR DESCRIPTION
This adds the ability to convert individual Loki queries into event count correlations by converting them into metric queries. It allows grouping by multiple fields, or none, as required and supports all current conditions and time-spans.

The feature does not yet support multiple queries, which may not be fully achievable using metric queries, and may require generating custom alerting configuration instead.