### PR TITLE
Fix regular expression modifiers

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -243,30 +243,33 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "filelock"
-version = "3.16.0"
+version = "3.16.1"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.16.0-py3-none-any.whl", hash = "sha256:f6ed4c963184f4c84dd5557ce8fece759a3724b37b80c6c4f20a2f63a4dc6609"},
-    {file = "filelock-3.16.0.tar.gz", hash = "sha256:81de9eb8453c769b63369f87f11131a7ab04e367f8d97ad39dc230daa07e3bec"},
+    {file = "filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0"},
+    {file = "filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"},
 ]
 
 [package.extras]
-docs = ["furo (>=2024.8.6)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.1.1)", "pytest (>=8.3.2)", "pytest-asyncio (>=0.24)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.26.3)"]
+docs = ["furo (>=2024.8.6)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4.1)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.2)", "pytest (>=8.3.3)", "pytest-asyncio (>=0.24)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.26.4)"]
 typing = ["typing-extensions (>=4.12.2)"]
 
 [[package]]
 name = "idna"
-version = "3.8"
+version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "idna-3.8-py3-none-any.whl", hash = "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac"},
-    {file = "idna-3.8.tar.gz", hash = "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"},
+    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
+    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
 ]
+
+[package.extras]
+all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -465,13 +468,13 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pysigma"
-version = "0.11.13"
+version = "0.11.14"
 description = "Sigma rule processing and conversion tools"
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "pysigma-0.11.13-py3-none-any.whl", hash = "sha256:e5add765484af9a292aa39ff45e3fcda4fa6417a090814ad722f80c88f8ad437"},
-    {file = "pysigma-0.11.13.tar.gz", hash = "sha256:4f226f7ef7c39e343cb5e5dd6681209fa6ce45a12e3194d600dbd914116f5cb3"},
+    {file = "pysigma-0.11.14-py3-none-any.whl", hash = "sha256:682f102e4b9feda0cadab41e1d81239666a89516b156f1a33f84fa17167dc354"},
+    {file = "pysigma-0.11.14.tar.gz", hash = "sha256:89f202580684f775af25127a647e883dbce54cc177a3c5a203233cb47c20e08f"},
 ]
 
 [package.dependencies]
@@ -689,13 +692,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.2"
+version = "2.2.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "urllib3-2.2.2-py3-none-any.whl", hash = "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472"},
-    {file = "urllib3-2.2.2.tar.gz", hash = "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"},
+    {file = "urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac"},
+    {file = "urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"},
 ]
 
 [package.extras]
@@ -707,4 +710,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "648c9278e345aba6b493c1fcccdf7c5ec33f8ec781659b9f7b08dbcc1e6e0814"
+content-hash = "862e2df214b86e188bc54d0c8186d832cc77d9bedb1d001b66fd21db1d071751"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = [{ include = "sigma" }]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pysigma = "^0.11.13"
+pysigma = "^0.11.14"
 
 [tool.poetry.group.dev.dependencies]
 coverage = "^7.6.1"

--- a/sigma/backends/loki/loki.py
+++ b/sigma/backends/loki/loki.py
@@ -248,6 +248,7 @@ class LogQLBackend(TextQueryBackend):
     eq_token: ClassVar[str]
     field_null_expression: ClassVar[str]
     re_expression: ClassVar[str]
+    re_flag_prefix: bool = True
     cidr_expression: ClassVar[str]
     compare_op_expression: ClassVar[str]
     compare_operators: ClassVar[Dict[SigmaCompareExpression.CompareOperators, str]]
@@ -835,7 +836,7 @@ class LogQLBackend(TextQueryBackend):
     def convert_value_re(
         self, r: SigmaRegularExpression, state: ConversionState
     ) -> str:
-        return escape_and_quote_re(r)
+        return escape_and_quote_re(r, self.re_flag_prefix)
 
     def convert_condition_or(
         self, cond: ConditionOR, state: ConversionState

--- a/sigma/shared.py
+++ b/sigma/shared.py
@@ -74,12 +74,12 @@ def convert_str_to_re(
     )
 
 
-def escape_and_quote_re(r: SigmaRegularExpression) -> str:
+def escape_and_quote_re(r: SigmaRegularExpression, flag_prefix=True) -> str:
     """LogQL does not require any additional escaping for regular expressions if we
     can use the tilde character"""
     if "`" in r.regexp:
-        return '"' + r.escape(('"',)) + '"'
-    return "`" + r.regexp + "`"
+        return '"' + r.escape(('"',), flag_prefix=flag_prefix) + '"'
+    return "`" + r.escape((), "", False, flag_prefix) + "`"  # type: ignore
 
 
 def join_or_values_re(

--- a/tests/test_backend_loki_field_modifiers.py
+++ b/tests/test_backend_loki_field_modifiers.py
@@ -38,8 +38,8 @@ modifier_sample_data: Dict[str, Tuple[Any, str]] = {
     "wide": ("valueA", "fieldA=~`(?i)^v\x00a\x00l\x00u\x00e\x00A\x00$`"),
     "windash": ("-foo", "fieldA=~`(?i)^\\-foo$` or fieldA=~`(?i)^/foo$`"),
     "re": (".*valueA$", "fieldA=~`.*valueA$`"),
-    "i": ("valueA", "valueA"),
-    "ignorecase": ("valueA", "valueA"),
+    "i": ("valueA", "fieldA=~`(?i)valueA`"),
+    "ignorecase": ("valueA", "fieldA=~`(?i)valueA`"),
     # Multiline modifier is not supported by LogQL, and the recommended way to handle
     # multiline logs can be found below:
     # https://grafana.com/docs/loki/latest/send-data/promtail/stages/multiline/

--- a/tests/test_backend_loki_value_count_correlation.py
+++ b/tests/test_backend_loki_value_count_correlation.py
@@ -134,8 +134,6 @@ falsepositives:
     - If a user requires an anonymising proxy due to valid justifications.
 level: high
 ---
-# Note: using transformed field names as LogsourceConditions do not currently support correlation 
-# rules
 title: Okta User Activity Across Multiple Countries
 id: a8c75573-8513-40c6-85a6-818b7c58a601
 author: kelnage
@@ -146,10 +144,10 @@ correlation:
     rules:
         - 79bbc335-7ab0-4316-a17b-30c85f7f0595
     group-by:
-        - event_actor_alternateId
+        - actor.alternateid
     timespan: 1h
     condition:
-        field: event_client_geographicalContext_country
+        field: client.geographicalcontext.country
         gt: 1
 level: high
 """


### PR DESCRIPTION
Update the conversion of regular expressions to ensure the modifiers are included.

Also updates to the latest version of pySigma and removes the log source condition workaround from our test case as it is no longer required.

Fixes #154 