### PR TITLE
Fix keywords custom log source

### DIFF
--- a/sigma/pipelines/loki/loki.py
+++ b/sigma/pipelines/loki/loki.py
@@ -165,8 +165,12 @@ class CustomLogSourceTransformation(Transformation):
                     values = []
                     negated = None
                     for item in rule_conditions:
-                        if item.field == value.field and isinstance(
-                            item.value, (SigmaString, SigmaRegularExpression)
+                        if (
+                            isinstance(item, ConditionFieldEqualsValueExpression)
+                            and item.field == value.field
+                            and isinstance(
+                                item.value, (SigmaString, SigmaRegularExpression)
+                            )
                         ):
                             classes = item.parent_chain_condition_classes()
                             new_negated = count_negated(classes) % 2 == 1

--- a/tests/test_backend_loki_event_count_correlation.py
+++ b/tests/test_backend_loki_event_count_correlation.py
@@ -37,8 +37,10 @@ correlation:
 """
     )
     queries = loki_backend.convert(rules)
-    assert queries == ['sum(count_over_time({job=~".+"} | logfmt | '
-                       'fieldA=~`(?i)^valueA$` [30s])) == 42']
+    assert queries == [
+        'sum(count_over_time({job=~".+"} | logfmt | '
+        "fieldA=~`(?i)^valueA$` [30s])) == 42"
+    ]
 
 
 def test_loki_default_event_count_single_field(loki_backend: LogQLBackend):
@@ -69,8 +71,10 @@ correlation:
 """
     )
     queries = loki_backend.convert(rules)
-    assert queries == ['sum by (fieldB) (count_over_time({job=~".+"} | logfmt | '
-                       'fieldA=~`(?i)^valueA$` [5m])) >= 1']
+    assert queries == [
+        'sum by (fieldB) (count_over_time({job=~".+"} | logfmt | '
+        "fieldA=~`(?i)^valueA$` [5m])) >= 1"
+    ]
 
 
 def test_loki_default_event_count_multiple_fields(loki_backend: LogQLBackend):
@@ -102,8 +106,10 @@ correlation:
 """
     )
     queries = loki_backend.convert(rules)
-    assert queries == ['sum by (fieldB, fieldC) (count_over_time({job=~".+"} | logfmt | '
-                       'fieldA=~`(?i)^valueA$` [1d])) < 100']
+    assert queries == [
+        'sum by (fieldB, fieldC) (count_over_time({job=~".+"} | logfmt | '
+        "fieldA=~`(?i)^valueA$` [1d])) < 100"
+    ]
 
 
 def test_loki_default_event_count_field_mapping(loki_backend: LogQLBackend):
@@ -150,5 +156,7 @@ correlation:
     )
     loki_backend = LogQLBackend(processing_pipeline=pipeline)
     queries = loki_backend.convert(rules)
-    assert queries == ['sum by (fieldC) (count_over_time({job=~".+"} | logfmt | '
-                       'fieldA=~`(?i)^valueA$` and fieldC=~`(?i).*valueB.*` [36h])) <= 5000']
+    assert queries == [
+        'sum by (fieldC) (count_over_time({job=~".+"} | logfmt | '
+        "fieldA=~`(?i)^valueA$` and fieldC=~`(?i).*valueB.*` [36h])) <= 5000"
+    ]

--- a/tests/test_backend_loki_value_count_correlation.py
+++ b/tests/test_backend_loki_value_count_correlation.py
@@ -38,8 +38,10 @@ correlation:
 """
     )
     queries = loki_backend.convert(rules)
-    assert queries == ['count without (fieldB) (sum by (fieldB) (count_over_time({job=~".+"} | '
-                       'logfmt | fieldA=~`(?i)^valueA$` [30s]))) == 42']
+    assert queries == [
+        'count without (fieldB) (sum by (fieldB) (count_over_time({job=~".+"} | '
+        "logfmt | fieldA=~`(?i)^valueA$` [30s]))) == 42"
+    ]
 
 
 def test_loki_default_value_count_single_group(loki_backend: LogQLBackend):
@@ -71,8 +73,10 @@ correlation:
 """
     )
     queries = loki_backend.convert(rules)
-    assert queries == ['count without (fieldC) (sum by (fieldB, fieldC) (count_over_time('
-                       '{job=~".+"} | logfmt | fieldA=~`(?i)^valueA$` [5m]))) >= 1']
+    assert queries == [
+        "count without (fieldC) (sum by (fieldB, fieldC) (count_over_time("
+        '{job=~".+"} | logfmt | fieldA=~`(?i)^valueA$` [5m]))) >= 1'
+    ]
 
 
 def test_loki_default_value_count_multiple_fields(loki_backend: LogQLBackend):
@@ -105,8 +109,10 @@ correlation:
 """
     )
     queries = loki_backend.convert(rules)
-    assert queries == ['count without (fieldD) (sum by (fieldB, fieldC, fieldD) (count_over_time('
-                       '{job=~".+"} | logfmt | fieldA=~`(?i)^valueA$` [1d]))) < 100']
+    assert queries == [
+        "count without (fieldD) (sum by (fieldB, fieldC, fieldD) (count_over_time("
+        '{job=~".+"} | logfmt | fieldA=~`(?i)^valueA$` [1d]))) < 100'
+    ]
 
 
 def test_loki_okta_country_count():
@@ -154,9 +160,11 @@ level: high
     )
     loki_backend = LogQLBackend(processing_pipeline=pipeline)
     queries = loki_backend.convert(rules)
-    assert queries == ['count without (event_client_geographicalContext_country) '
-                       '(sum by (event_actor_alternateId, '
-                       'event_client_geographicalContext_country) '
-                       '(count_over_time({job=~".+"} | json | event_actor_alternateId!="" and '
-                       'event_client_geographicalContext_country!="" [1h]))) '
-                       '> 1']
+    assert queries == [
+        "count without (event_client_geographicalContext_country) "
+        "(sum by (event_actor_alternateId, "
+        "event_client_geographicalContext_country) "
+        '(count_over_time({job=~".+"} | json | event_actor_alternateId!="" and '
+        'event_client_geographicalContext_country!="" [1h]))) '
+        "> 1"
+    ]


### PR DESCRIPTION
When a Sigma rule contained a keywords selector in its detections, the `CustomLogSource` pipeline was trying to extract a field name from it regardless, but `ConditionValueExpressions` don't have a field (by design) and hence was raising an exception.

This adds a check to ensure the pipeline is only trying to look up fields from `ConditionFieldEqualsValueExpression` conditions.