### PR TITLE
Move from ubuntu-20.04 to ubuntu-latest

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ 'ubuntu-20.04' ]
+        os: [ 'ubuntu-latest' ]
         python-version: [ '3.9', '3.10', '3.11' ]
         poetry-version: [ '1.3' ]
     runs-on: ${{ matrix.os }}
@@ -42,7 +42,7 @@ jobs:
           flag-name: python-${{ matrix.python-version }}
   finish:
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Finish coveralls
         uses: coverallsapp/github-action@1.1.3


### PR DESCRIPTION
The Ubuntu 20.04 image is being deprecated by GitHub, so this PR moves the build processes to Ubuntu latest.