### PR TITLE
Field Sanitization

### DIFF
--- a/sigma/backends/loki/loki.py
+++ b/sigma/backends/loki/loki.py
@@ -1065,10 +1065,12 @@ class LogQLBackend(TextQueryBackend):
                 # Since absent_over_time returns a 1 when the condition is true, we need to update the condition to an equality condition
                 rule.condition.op = SigmaCorrelationConditionOperator.EQ
                 rule.condition.count = 1
+        fieldref = rule.condition.fieldref if isinstance(rule.condition, SigmaCorrelationCondition) else None
+        field = self.escape_and_quote_field(fieldref) if isinstance(fieldref, str) else fieldref
         return template.format(
             rule=rule,
             referenced_rules=self.convert_referenced_rules(rule.rules, method) if rule.rules else "",
-            field=rule.condition.fieldref if isinstance(rule.condition, SigmaCorrelationCondition) else None,
+            field=field,
             timespan=self.convert_timespan(rule.timespan, method),
             groupby=self.convert_correlation_aggregation_groupby_from_template(groups, method),
             search=search,

--- a/tests/test_backend_loki_value_count_correlation.py
+++ b/tests/test_backend_loki_value_count_correlation.py
@@ -2,7 +2,7 @@ import pytest
 from sigma.collection import SigmaCollection
 
 from sigma.backends.loki import LogQLBackend
-from sigma.pipelines.loki import loki_okta_system_log, pipelines
+from sigma.pipelines.loki import loki_okta_system_log
 
 
 @pytest.fixture

--- a/tests/test_backend_loki_value_count_correlation.py
+++ b/tests/test_backend_loki_value_count_correlation.py
@@ -1,9 +1,8 @@
 import pytest
-
-from sigma.backends.loki import LogQLBackend
 from sigma.collection import SigmaCollection
 
-from sigma.pipelines.loki import loki_okta_system_log
+from sigma.backends.loki import LogQLBackend
+from sigma.pipelines.loki import loki_okta_system_log, pipelines
 
 
 @pytest.fixture
@@ -167,4 +166,54 @@ level: high
         '(count_over_time({job=~".+"} | json | event_actor_alternateId!="" and '
         'event_client_geographicalContext_country!="" [1h]))) '
         "> 1"
+    ]
+
+
+def test_request_path_dotted():
+    rules = SigmaCollection.from_yaml(
+        """
+title: Sanitize test
+id: 7fbad3c7-7b5d-4362-9581-c814ca975b2f
+status: experimental
+description: Tests correlation with field value that should be sanitized
+author: TEST_RULE
+date: 2026-05-20
+correlation:
+    type: value_count
+    rules:
+        - a3ecb779-194e-4354-8dad-0fab37346670
+    group-by:
+        - auth.display_name
+    timespan: 1m
+    condition:
+        field: request.path
+        gt: 5
+level: high
+---
+title: Sanitize test base
+id: a3ecb779-194e-4354-8dad-0fab37346670
+status: experimental
+description: Tests sanitization of fields
+author: TEST_RULE
+date: 2026-05-20
+tags:
+    - attack.discovery
+    - attack.t1083
+    - attack.credential_access
+logsource:
+    product: test
+    service: test
+detection:
+    selection:
+        request.type: "response"
+        request.op: "read"
+    condition: selection
+level: informational
+        """
+    )
+
+    loki_backend = LogQLBackend()
+    queries = loki_backend.convert(rules)
+    assert queries == [
+        'count without (request_path) (sum by (auth_display_name, request_path) (count_over_time({job=~".+"} | logfmt | request_type=~`(?i)^response$` and request_op=~`(?i)^read$` [1m]))) > 5'
     ]


### PR DESCRIPTION
There's a small bug that means that the `without` clause in LogQL is not using properly sanitized fields, this fixes that by passing in the sanitization. We were seeing that correlations were returning `without (request.path)` instead of `without (request_path)` which causes the LogQL parser to fail when running the rules in Grafana