### PR TITLE
Improve workflow security and use Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,10 @@ on:
       - v*.*.*
 
 jobs:
-  build-and-publish:
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -34,20 +33,42 @@ jobs:
         run: poetry run pytest
       - name: Build packages
         run: poetry build
-      - name: Get service account token for PyPI
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
+      - name: Upload dist
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          repo_secrets: |
-            TEST_PYPI_API_TOKEN=pypi-deploy:pypi_test
-            PYPI_API_TOKEN=pypi-deploy:pypi_main
-      - name: Configure Poetry
-        run: |
-          poetry config repositories.testpypi https://test.pypi.org/legacy/
-          poetry config pypi-token.testpypi "${{ env.TEST_PYPI_API_TOKEN }}"
-          poetry config pypi-token.pypi "${{ env.PYPI_API_TOKEN }}"
-      - name: Publish to test PyPI
-        if: ${{ github.event_name == 'push' }}
-        run: poetry publish -r testpypi
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dist
+          path: dist/
       - name: Publish to PyPI
-        if: ${{ github.event_name == 'release' }}
-        run: poetry publish
+        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build packages
         run: poetry build
       - name: Get service account token for PyPI
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
           repo_secrets: |
             TEST_PYPI_API_TOKEN=pypi-deploy:pypi_test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      statuses: write
     strategy:
       matrix:
         os: [ 'ubuntu-latest' ]
@@ -45,6 +47,8 @@ jobs:
           flag-name: python-${{ matrix.python-version }}
   finish:
     needs: test
+    permissions:
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       - name: Finish coveralls

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -1,4 +1,5 @@
 name: Validate Renovate Config
+permissions: {}
 
 on:
   pull_request:


### PR DESCRIPTION
Key changes:

* Migrate to [trusted publishing](https://docs.pypi.org/trusted-publishers/using-a-publisher/) for more secure releases
* Introduce `status: write` permission for the Coveralls test workflow
* Set minimum required permissions for validating renovate config