### PR TITLE
Pin socket-export-sbom to released v1.0.0

### DIFF
--- a/.github/workflows/sbom-release.yml
+++ b/.github/workflows/sbom-release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: "Export SPDX SBOM from Socket"
         id: export-sbom
-        uses: grafana/shared-workflows/actions/socket-export-sbom@961ad0e6e148fe101a8be4ad6b2fb3f0569bb7eb # ezebunandu/socket-branch-specific-sbom
+        uses: grafana/shared-workflows/actions/socket-export-sbom@73f73d35ceadf46221741d45faefec0c5a990e6b # socket-export-sbom/v1.0.0
         with:
           socket_api_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).SOCKET_API_TOKEN }}
           socket_org: grafana


### PR DESCRIPTION
Repins socket-export-sbom from the ezebunandu/socket-branch-specific-sbom branch SHA to the released socket-export-sbom/v1.0.0. Same code, now tagged — no input or output changes, so nothing else in the workflow moves.