### PR TITLE
Pin socket-export-sbom to unreleased commit for testing

### DIFF
--- a/.github/workflows/sbom-release.yml
+++ b/.github/workflows/sbom-release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: "Export SPDX SBOM from Socket"
         id: export-sbom
-        uses: grafana/shared-workflows/actions/socket-export-sbom@73f73d35ceadf46221741d45faefec0c5a990e6b # socket-export-sbom/v1.0.0
+        uses: grafana/shared-workflows/actions/socket-export-sbom@5e31abaa7ebe57af7ce159969512fea1c6408678 # testing unreleased changes
         with:
           socket_api_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).SOCKET_API_TOKEN }}
           socket_org: grafana


### PR DESCRIPTION
My hunch is that the cloudflare bot block causing the 403 blocks on SBOM export is due to the use of a curl request with no UA following spate of requests from socket's official node CLI to first create the scan.

This change is to test a new version of the shared workflow that attempts to fix the 403 blocks by using node code for the SBOM export stage, with better retry logic and error handling.

See [draft PR](https://github.com/grafana/shared-workflows/pull/2258) for more context.