### PR TITLE
references the version of the workflow with the path regression fix

### DIFF
--- a/.github/workflows/sbom-release.yml
+++ b/.github/workflows/sbom-release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: "Export SPDX SBOM from Socket"
         id: export-sbom
-        uses: grafana/shared-workflows/actions/socket-export-sbom@5e31abaa7ebe57af7ce159969512fea1c6408678 # testing unreleased changes
+        uses: grafana/shared-workflows/actions/socket-export-sbom@5b7708439f1234f20c3cbc13ff2fd9e3e962a725 # testing unreleased changes
         with:
           socket_api_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).SOCKET_API_TOKEN }}
           socket_org: grafana


### PR DESCRIPTION
references the commit of the shared workflow with a fix for the slash handling regression unintentionally introduced.

See [commit](https://github.com/grafana/shared-workflows/pull/2258/changes/5b7708439f1234f20c3cbc13ff2fd9e3e962a725) for more context.